### PR TITLE
Do not respawn SadTalker jobs when face detection fails

### DIFF
--- a/crates/service/job/inference_job/src/job/job_loop/main_loop.rs
+++ b/crates/service/job/inference_job/src/job/job_loop/main_loop.rs
@@ -135,6 +135,8 @@ async fn process_job_batch(job_dependencies: &JobDependencies, jobs: Vec<Availab
                 (true, false, format!("InvalidJob: {:?}", err), Some("invalid job")),
               ProcessSingleJobError::NotYetImplemented =>
                 (true, false, "not yet implemented".to_string(), Some("not yet implemented")),
+              ProcessSingleJobError::FaceDetectionFailure =>
+                (true, false, "face not detected".to_string(), Some("face not detected")),
 
               // Non-permanent failures
               ProcessSingleJobError::FilesystemFull =>
@@ -177,6 +179,7 @@ async fn process_job_batch(job_dependencies: &JobDependencies, jobs: Vec<Availab
           ProcessSingleJobError::InvalidJob(_) => {}
           ProcessSingleJobError::KeepAliveElapsed => {}
           ProcessSingleJobError::NotYetImplemented => {}
+          ProcessSingleJobError::FaceDetectionFailure => {}
         }
       }
     }

--- a/crates/service/job/inference_job/src/job/job_loop/process_single_job_error.rs
+++ b/crates/service/job/inference_job/src/job/job_loop/process_single_job_error.rs
@@ -3,6 +3,11 @@ use anyhow::anyhow;
 /// Error from processing a single job
 #[derive(Debug)]
 pub enum ProcessSingleJobError {
+  /// For inference jobs that are required to find faces, fail the job
+  /// immediately if no face is found. We can also surface the error to
+  /// the user in a friendly way.
+  /// Example job types: SadTalker, Wav2Lip.
+  FaceDetectionFailure,
   /// The filesystem is out of space and we need to free it up.
   FilesystemFull,
   /// The job is invalid (bad state, etc.)


### PR DESCRIPTION
Currently SadTalker jobs will retry on failure, which is great for worker nodes with transient issues. Unfortunately failure to detect a face is a common user input error occuring in just around half of all image uploads. This will permanently tombstone these jobs.

The new failure class can be reused for future animation systems that rely on face detection.

There is still some minor work to do to surface this error to the frontend / user in a friendly way.