### PR TITLE
Add media prefix and file extension

### DIFF
--- a/_sql/migrations/2023-10-01-212745_alter_media_files_add_bucket_extension/down.sql
+++ b/_sql/migrations/2023-10-01-212745_alter_media_files_add_bucket_extension/down.sql
@@ -1,0 +1,5 @@
+-- noinspection SqlDialectInspectionForFile
+-- noinspection SqlNoDataSourceInspectionForFile
+-- noinspection SqlResolveForFile
+
+ALTER TABLE media_files DROP COLUMN maybe_public_bucket_extension;

--- a/_sql/migrations/2023-10-01-212745_alter_media_files_add_bucket_extension/up.sql
+++ b/_sql/migrations/2023-10-01-212745_alter_media_files_add_bucket_extension/up.sql
@@ -1,0 +1,7 @@
+-- noinspection SqlDialectInspectionForFile
+-- noinspection SqlNoDataSourceInspectionForFile
+-- noinspection SqlResolveForFile
+
+ALTER TABLE media_files
+    ADD COLUMN maybe_public_bucket_extension VARCHAR(16) DEFAULT NULL
+    AFTER public_bucket_directory_hash;

--- a/_sql/migrations/2023-10-04-062503_alter_media_files_add_bucket_prefix/down.sql
+++ b/_sql/migrations/2023-10-04-062503_alter_media_files_add_bucket_prefix/down.sql
@@ -1,0 +1,5 @@
+-- noinspection SqlDialectInspectionForFile
+-- noinspection SqlNoDataSourceInspectionForFile
+-- noinspection SqlResolveForFile
+
+ALTER TABLE media_files DROP COLUMN maybe_public_bucket_prefix;

--- a/_sql/migrations/2023-10-04-062503_alter_media_files_add_bucket_prefix/up.sql
+++ b/_sql/migrations/2023-10-04-062503_alter_media_files_add_bucket_prefix/up.sql
@@ -1,0 +1,7 @@
+-- noinspection SqlDialectInspectionForFile
+-- noinspection SqlNoDataSourceInspectionForFile
+-- noinspection SqlResolveForFile
+
+ALTER TABLE media_files
+    ADD COLUMN maybe_public_bucket_prefix VARCHAR(16) DEFAULT NULL
+    AFTER public_bucket_directory_hash;

--- a/_sql/migrations_squashed/media_files.sql
+++ b/_sql/migrations_squashed/media_files.sql
@@ -88,12 +88,22 @@ CREATE TABLE media_files (
 
   -- The hash for the bucket directory that contains the original upload
   -- as well as any transcodings, downsamplings, etc.
+  -- The bucket filename for the primary file (not including the directory path) is given by:
+  -- `[{maybe_public_bucket_prefix}]{public_bucket_directory_hash}[{maybe_public_bucket_extension}]`
   public_bucket_directory_hash  VARCHAR(32) NOT NULL,
 
-  -- An appended extension on the bucket filename.
+  -- An optional prefix on the bucket filename.
+  -- If present, this will be prepended to the beginning of the bucket filename to access the file.
+  -- The bucket filename for the primary file (not including the directory path) is given by:
+  -- `[{maybe_public_bucket_prefix}]{public_bucket_directory_hash}[{maybe_public_bucket_extension}]`
+  maybe_public_bucket_prefix VARCHAR(16) DEFAULT NULL,
+
+  -- An optional appended extension on the bucket filename.
   -- If present, this will be appended to the end of the bucket filename to access the file.
   -- To allow for flexibility, this extension typically will contain a leading period if
   -- the file needs it (eg ".mp4" rather than "mp4")!
+  -- The bucket filename for the primary file (not including the directory path) is given by:
+  -- `[{maybe_public_bucket_prefix}]{public_bucket_directory_hash}[{maybe_public_bucket_extension}]`
   maybe_public_bucket_extension VARCHAR(16) DEFAULT NULL,
 
   -- NB: Removed, since this can be derived.

--- a/_sql/migrations_squashed/media_files.sql
+++ b/_sql/migrations_squashed/media_files.sql
@@ -90,6 +90,12 @@ CREATE TABLE media_files (
   -- as well as any transcodings, downsamplings, etc.
   public_bucket_directory_hash  VARCHAR(32) NOT NULL,
 
+  -- An appended extension on the bucket filename.
+  -- If present, this will be appended to the end of the bucket filename to access the file.
+  -- To allow for flexibility, this extension typically will contain a leading period if
+  -- the file needs it (eg ".mp4" rather than "mp4")!
+  maybe_public_bucket_extension VARCHAR(16) DEFAULT NULL,
+
   -- NB: Removed, since this can be derived.
   -- The directory this media is uploaded to will be exclusive for this file.
   -- Only this given record will live in this bucket, but the directory may include

--- a/crates/_types/buckets/src/public/media_files/original_file.rs
+++ b/crates/_types/buckets/src/public/media_files/original_file.rs
@@ -14,25 +14,43 @@ const ORIGINAL_FILE_BASENAME : &str = "file.bin";
 #[derive(Clone)]
 pub struct MediaFileBucketPath {
   directory: MediaFileBucketDirectory,
+
+  filename: String,
   full_object_path: String,
+
+  optional_prefix: Option<String>,
+  /// NB: Extension contains the leading period, eg. ".mp4"
+  optional_extension: Option<String>,
 }
 
 impl PublicPath for MediaFileBucketPath {}
 
 impl MediaFileBucketPath {
 
-  pub fn generate_new() -> Self {
+  pub fn generate_new(optional_prefix: Option<&str>, optional_extension: Option<&str>) -> Self {
     let entropy = crockford_entropy_lower(32);
-    Self::from_object_hash(&entropy)
+    Self::from_object_hash(&entropy, optional_prefix, optional_extension)
   }
 
-  pub fn from_object_hash(hash: &str) -> Self {
+  pub fn from_object_hash(hash: &str, optional_prefix: Option<&str>, optional_extension: Option<&str>) -> Self {
     // TODO: Path construction could be cleaner.
     let directory = MediaFileBucketDirectory::from_object_hash(hash);
-    let full_object_path = format!("{}/{}", directory.get_directory_path_str(), ORIGINAL_FILE_BASENAME);
+
+    let filename = match (optional_prefix, optional_extension) {
+      (None, None) => ORIGINAL_FILE_BASENAME.to_string(),
+      (None, Some(ext)) => format!("{}{}", hash, ext),
+      (Some(pre), None) => format!("{}{}", pre, hash),
+      (Some(pre), Some(ext)) => format!("{}{}{}", pre, hash, ext),
+    };
+
+    let full_object_path = format!("{}/{}", directory.get_directory_path_str(), filename);
+
     Self {
       directory,
+      filename,
       full_object_path,
+      optional_prefix: optional_prefix.map(|p| p.to_string()),
+      optional_extension: optional_extension.map(|e| e.to_string()),
     }
   }
 
@@ -52,8 +70,8 @@ impl MediaFileBucketPath {
     &self.directory.get_object_hash()
   }
 
-  pub fn get_basename() -> &'static str {
-    ORIGINAL_FILE_BASENAME
+  pub fn get_basename(&self) -> &str {
+    &self.filename
   }
 }
 
@@ -63,42 +81,65 @@ mod tests {
 
   use crate::public::media_files::original_file::MediaFileBucketPath;
 
-  #[test]
-  pub fn generate_new_entropy() {
-    let file = MediaFileBucketPath::generate_new();
-    assert_eq!(file.get_object_hash().len(), 32);
-    assert_eq!(file.get_directory().get_object_hash().len(), 32);
+  mod with_prefix_and_extension {
+    use super::*;
+
+    #[test]
+    pub fn generate_new_entropy() {
+      let file = MediaFileBucketPath::generate_new(Some("pre_"), Some(".mp4"));
+      assert_eq!(file.get_object_hash().len(), 32);
+      assert_eq!(file.get_object_hash().len(), 32);
+      assert_eq!(file.get_directory().get_object_hash().len(), 32);
+    }
+
+    #[test]
+    pub fn get_full_object_path_str() {
+      let file = MediaFileBucketPath::from_object_hash("abcdefghijk", Some("pre_"), Some(".mp4"));
+      assert_eq!(file.get_full_object_path_str(), "/media/a/b/c/d/e/abcdefghijk/pre_abcdefghijk.mp4");
+      assert_eq!(file.get_basename(), "pre_abcdefghijk.mp4");
+    }
   }
 
-  #[test]
-  pub fn get_full_object_path_str() {
-    let file = MediaFileBucketPath::from_object_hash("abcdefghijk");
-    assert_eq!(file.get_full_object_path_str(), "/media/a/b/c/d/e/abcdefghijk/file.bin");
-  }
+  mod without_prefix_and_extension {
+    use super::*;
 
-  #[test]
-  pub fn to_full_object_pathbuf() {
-    let file = MediaFileBucketPath::from_object_hash("abcdefghijk");
-    assert_eq!(file.to_full_object_pathbuf(), PathBuf::from("/media/a/b/c/d/e/abcdefghijk/file.bin"));
-  }
+    #[test]
+    pub fn generate_new_entropy() {
+      let file = MediaFileBucketPath::generate_new(None, None);
+      assert_eq!(file.get_object_hash().len(), 32);
+      assert_eq!(file.get_directory().get_object_hash().len(), 32);
+    }
 
-  #[test]
-  pub fn get_full_object_path_str_short_name() {
-    let file = MediaFileBucketPath::from_object_hash("foo");
-    assert_eq!(file.get_full_object_path_str(), "/media/f/o/foo/file.bin");
-  }
+    #[test]
+    pub fn get_full_object_path_str() {
+      let file = MediaFileBucketPath::from_object_hash("abcdefghijk", None, None);
+      assert_eq!(file.get_full_object_path_str(), "/media/a/b/c/d/e/abcdefghijk/file.bin");
+    }
 
-  #[test]
-  pub fn get_full_object_path_str_starts_with_directory() {
-    let file = MediaFileBucketPath::from_object_hash("abcdefghijk");
-    let full_path = file.get_full_object_path_str();
-    assert!(full_path.starts_with(file.get_directory().get_directory_path_str()))
-  }
+    #[test]
+    pub fn to_full_object_pathbuf() {
+      let file = MediaFileBucketPath::from_object_hash("abcdefghijk", None, None);
+      assert_eq!(file.to_full_object_pathbuf(), PathBuf::from("/media/a/b/c/d/e/abcdefghijk/file.bin"));
+    }
 
-  #[test]
-  pub fn get_object_hash() {
-    let hash = "abcdefghijk";
-    let file = MediaFileBucketPath::from_object_hash(hash);
-    assert_eq!(file.get_object_hash(), hash);
+    #[test]
+    pub fn get_full_object_path_str_short_name() {
+      let file = MediaFileBucketPath::from_object_hash("foo", None, None);
+      assert_eq!(file.get_full_object_path_str(), "/media/f/o/foo/file.bin");
+    }
+
+    #[test]
+    pub fn get_full_object_path_str_starts_with_directory() {
+      let file = MediaFileBucketPath::from_object_hash("abcdefghijk", None, None);
+      let full_path = file.get_full_object_path_str();
+      assert!(full_path.starts_with(file.get_directory().get_directory_path_str()))
+    }
+
+    #[test]
+    pub fn get_object_hash() {
+      let hash = "abcdefghijk";
+      let file = MediaFileBucketPath::from_object_hash(hash, None, None);
+      assert_eq!(file.get_object_hash(), hash);
+    }
   }
 }

--- a/crates/lib/mysql_queries/src/queries/generic_inference/web/get_inference_job_status.rs
+++ b/crates/lib/mysql_queries/src/queries/generic_inference/web/get_inference_job_status.rs
@@ -45,6 +45,8 @@ pub struct ResultDetails {
 
   /// The bucket storage hash (for vc and media_files) or full path (for tts)
   pub public_bucket_location_or_hash: String,
+  pub maybe_media_file_public_bucket_prefix: Option<String>,
+  pub maybe_media_file_public_bucket_extension: Option<String>,
 
   /// Whether the location is a full path (for tts) or a hash (for vc) that
   /// needs to be reconstructed into a path.
@@ -84,6 +86,8 @@ SELECT
     tts_results.public_bucket_wav_audio_path as maybe_tts_public_bucket_path,
     voice_conversion_results.public_bucket_hash as maybe_voice_conversion_public_bucket_hash,
     media_files.public_bucket_directory_hash as maybe_media_file_public_bucket_directory_hash,
+    media_files.maybe_public_bucket_prefix as maybe_media_file_public_bucket_prefix,
+    media_files.maybe_public_bucket_extension as maybe_media_file_public_bucket_extension,
 
     jobs.assigned_worker as maybe_assigned_worker,
     jobs.assigned_cluster as maybe_assigned_cluster,
@@ -149,6 +153,8 @@ WHERE jobs.token = ?
                   entity_type: entity_type.to_string(),
                   entity_token: entity_token.to_string(),
                   public_bucket_location_or_hash: public_bucket_hash.to_string(),
+                  maybe_media_file_public_bucket_prefix: record.maybe_media_file_public_bucket_prefix.clone(),
+                  maybe_media_file_public_bucket_extension: record.maybe_media_file_public_bucket_extension.clone(),
                   public_bucket_location_is_hash: bucket_path_is_hash,
                   maybe_successfully_completed_at: record.maybe_successfully_completed_at.clone(),
                 }
@@ -197,6 +203,8 @@ struct RawGenericInferenceJobStatus {
   pub maybe_voice_conversion_public_bucket_hash: Option<String>, // NB: This is the bucket hash.
   pub maybe_tts_public_bucket_path: Option<String>, // NB: This isn't the bucket path, but the whole hash.
   pub maybe_media_file_public_bucket_directory_hash: Option<String>, // NB: This is the bucket directory hash
+  pub maybe_media_file_public_bucket_prefix: Option<String>,
+  pub maybe_media_file_public_bucket_extension: Option<String>,
 
   pub maybe_assigned_worker: Option<String>,
   pub maybe_assigned_cluster: Option<String>,

--- a/crates/lib/mysql_queries/src/queries/media_files/insert_media_file_from_face_animation.rs
+++ b/crates/lib/mysql_queries/src/queries/media_files/insert_media_file_from_face_animation.rs
@@ -24,6 +24,7 @@ pub struct InsertArgs<'a> {
   //pub duration_millis: u64,
 
   pub public_bucket_directory_hash: &'a str,
+  pub maybe_public_bucket_prefix: Option<&'a str>,
   pub maybe_public_bucket_extension: Option<&'a str>,
 
   pub is_on_prem: bool,
@@ -86,6 +87,7 @@ SET
   checksum_sha2 = ?,
 
   public_bucket_directory_hash = ?,
+  maybe_public_bucket_prefix = ?,
   maybe_public_bucket_extension = ?,
 
   maybe_creator_user_token = ?,
@@ -113,6 +115,7 @@ SET
       args.sha256_checksum,
 
       args.public_bucket_directory_hash,
+      args.maybe_public_bucket_prefix,
       args.maybe_public_bucket_extension,
 
       args.job.maybe_creator_user_token,

--- a/crates/lib/mysql_queries/src/queries/media_files/insert_media_file_from_face_animation.rs
+++ b/crates/lib/mysql_queries/src/queries/media_files/insert_media_file_from_face_animation.rs
@@ -24,6 +24,7 @@ pub struct InsertArgs<'a> {
   //pub duration_millis: u64,
 
   pub public_bucket_directory_hash: &'a str,
+  pub maybe_public_bucket_extension: Option<&'a str>,
 
   pub is_on_prem: bool,
   pub worker_hostname: &'a str,
@@ -85,6 +86,7 @@ SET
   checksum_sha2 = ?,
 
   public_bucket_directory_hash = ?,
+  maybe_public_bucket_extension = ?,
 
   maybe_creator_user_token = ?,
   creator_ip_address = ?,
@@ -111,6 +113,7 @@ SET
       args.sha256_checksum,
 
       args.public_bucket_directory_hash,
+      args.maybe_public_bucket_extension,
 
       args.job.maybe_creator_user_token,
       args.job.creator_ip_address,

--- a/crates/service/job/inference_job/src/job/job_types/lipsync/sad_talker/process_job.rs
+++ b/crates/service/job/inference_job/src/job/job_types/lipsync/sad_talker/process_job.rs
@@ -29,6 +29,9 @@ use crate::util::common_commands::ffmpeg_logo_watermark_command;
 /// The maximum that either width or height can be
 const MAX_DIMENSION : u32 = 1500;
 
+const BUCKET_FILE_PREFIX: &str = "fakeyou_";
+const BUCKET_FILE_EXTENSION: &str = ".mp4";
+
 pub struct SadTalkerProcessJobArgs<'a> {
   pub job_dependencies: &'a JobDependencies,
   pub job: &'a AvailableInferenceJob,
@@ -288,7 +291,9 @@ pub async fn process_job(args: SadTalkerProcessJobArgs<'_>) -> Result<JobSuccess
   job_progress_reporter.log_status("uploading result")
       .map_err(|e| ProcessSingleJobError::Other(e))?;
 
-  let result_bucket_location = MediaFileBucketPath::generate_new();
+  let result_bucket_location = MediaFileBucketPath::generate_new(
+    Some(BUCKET_FILE_PREFIX),
+    Some(BUCKET_FILE_EXTENSION));
 
   let result_bucket_object_pathbuf = result_bucket_location.to_full_object_pathbuf();
 
@@ -323,7 +328,8 @@ pub async fn process_job(args: SadTalkerProcessJobArgs<'_>) -> Result<JobSuccess
     file_size_bytes,
     sha256_checksum: &file_checksum,
     public_bucket_directory_hash: result_bucket_location.get_object_hash(),
-    maybe_public_bucket_extension: None, // TODO(bt,2023-10-02): Add extension '.mp4'
+    maybe_public_bucket_prefix: Some(BUCKET_FILE_PREFIX),
+    maybe_public_bucket_extension: Some(BUCKET_FILE_EXTENSION),
     is_on_prem: args.job_dependencies.container.is_on_prem,
     worker_hostname: &args.job_dependencies.container.hostname,
     worker_cluster: &args.job_dependencies.container.cluster_name,

--- a/crates/service/job/inference_job/src/job/job_types/lipsync/sad_talker/process_job.rs
+++ b/crates/service/job/inference_job/src/job/job_types/lipsync/sad_talker/process_job.rs
@@ -227,7 +227,7 @@ pub async fn process_job(args: SadTalkerProcessJobArgs<'_>) -> Result<JobSuccess
 
   check_file_exists(&output_video_fs_path).map_err(|e| ProcessSingleJobError::Other(e))?;
 
-  // ==================== WATERMARK ==================== //
+  // ==================== OPTIONAL WATERMARK ==================== //
 
   let mut finished_file = output_video_fs_path.clone();
 
@@ -258,7 +258,6 @@ pub async fn process_job(args: SadTalkerProcessJobArgs<'_>) -> Result<JobSuccess
       return Err(ProcessSingleJobError::Other(anyhow!("CommandExitStatus: {:?}", command_exit_status)));
     }
   }
-
 
   // ==================== CHECK ALL FILES EXIST AND GET METADATA ==================== //
 
@@ -324,6 +323,7 @@ pub async fn process_job(args: SadTalkerProcessJobArgs<'_>) -> Result<JobSuccess
     file_size_bytes,
     sha256_checksum: &file_checksum,
     public_bucket_directory_hash: result_bucket_location.get_object_hash(),
+    maybe_public_bucket_extension: None, // TODO(bt,2023-10-02): Add extension '.mp4'
     is_on_prem: args.job_dependencies.container.is_on_prem,
     worker_hostname: &args.job_dependencies.container.hostname,
     worker_cluster: &args.job_dependencies.container.cluster_name,

--- a/crates/service/web/storyteller_web/src/http_server/endpoints/inference_job/get_inference_job_status.rs
+++ b/crates/service/web/storyteller_web/src/http_server/endpoints/inference_job/get_inference_job_status.rs
@@ -207,7 +207,10 @@ pub async fn get_inference_job_status_handler(
     maybe_result: record.maybe_result_details.map(|result_details| {
       let public_bucket_media_path = match inference_category {
         InferenceCategory::LipsyncAnimation => {
-          MediaFileBucketPath::from_object_hash(&result_details.public_bucket_location_or_hash)
+          MediaFileBucketPath::from_object_hash(
+            &result_details.public_bucket_location_or_hash,
+            result_details.maybe_media_file_public_bucket_prefix.as_deref(),
+          result_details.maybe_media_file_public_bucket_extension.as_deref())
               .get_full_object_path_str()
               .to_string()
         }


### PR DESCRIPTION
Downloading "file.bin" was a horrible idea. No branding, dangerous file extension, all files named the same. This fixes that by storing files by "{prefix}{hash}{extension}", all of which are customizable on a case-by-case basis.