### PR TITLE
Upgrade sqlx to latest (0.7.2)

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -1,0 +1,14 @@
+hakari-package = "my-workspace-hack"
+
+resolver = "1"
+
+dep-format-version = "4"
+workspace-hack-line-style = "workspace-dotted"
+
+platforms = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+
+exact-versions = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
  "h2 0.2.7",
  "http",
  "httparse",
- "indexmap",
+ "indexmap 1.9.2",
  "itoa 0.4.7",
  "language-tags 0.2.2",
  "lazy_static",
@@ -722,6 +722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "atoi"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c57d12312ff59c811c0643f4d80830505833c9ffaebd193d819392b265be8e"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
@@ -1090,6 +1099,9 @@ name = "bitflags"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block-buffer"
@@ -1309,15 +1321,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time 0.1.44",
+ "wasm-bindgen",
  "winapi 0.3.9",
 ]
 
@@ -1513,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
 name = "const_fn"
@@ -1735,16 +1749,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1919,13 +1923,13 @@ checksum = "4460596867846f73bddca51f7403b6a29f5315125be10a1640259b4db5b9494c"
 
 [[package]]
 name = "der"
-version = "0.5.1"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
- "crypto-bigint",
  "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -2081,11 +2085,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.3",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -2436,6 +2441,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "sqlx-core",
+ "sqlx-mysql",
  "strum",
  "toml",
 ]
@@ -2467,6 +2473,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2496,6 +2508,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if 1.0.0",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2508,7 +2531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1e481eb11a482815d3e9d618db8c42a93207134662873809335a92327440c18"
 dependencies = [
  "bit_field",
- "flume",
+ "flume 0.10.14",
  "half",
  "lebe",
  "miniz_oxide",
@@ -2578,7 +2601,18 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project 1.0.7",
- "spin 0.9.4",
+ "spin 0.9.8",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2700,13 +2734,13 @@ dependencies = [
 
 [[package]]
 name = "futures-intrusive"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62007592ac46aa7c2b6416f7deb9a8a8f63a01e0f1d6e1787d5630170db2b63e"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api 0.4.6",
- "parking_lot 0.11.1",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -2863,7 +2897,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.2",
  "slab",
  "tokio 0.2.25",
  "tokio-util 0.3.1",
@@ -2883,7 +2917,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.2",
  "slab",
  "tokio 1.34.0",
  "tokio-util 0.7.4",
@@ -2925,7 +2959,7 @@ dependencies = [
  "bcrypt",
  "data-encoding",
  "errors",
- "md-5",
+ "md-5 0.9.1",
  "my-workspace-hack",
  "ring 0.17.0-alpha.11",
 ]
@@ -2979,6 +3013,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,7 +3037,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3160,6 +3212,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "idempotency"
 version = "0.0.1"
 dependencies = [
@@ -3231,6 +3306,16 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -3557,9 +3642,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3695,7 +3780,7 @@ dependencies = [
  "crc-any",
  "des",
  "digest 0.9.0",
- "md-5",
+ "md-5 0.9.1",
  "sha2 0.9.5",
  "tiger",
 ]
@@ -3752,6 +3837,16 @@ dependencies = [
  "block-buffer 0.9.0",
  "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if 1.0.0",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3931,8 +4026,10 @@ version = "0.1.0"
 dependencies = [
  "actix-rt 2.9.0",
  "ahash 0.7.6",
+ "ahash 0.8.3",
+ "base64 0.21.0",
  "base64ct",
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "block-buffer 0.9.0",
  "bytemuck",
  "byteorder",
@@ -3941,32 +4038,31 @@ dependencies = [
  "combine 4.6.3",
  "crossbeam-utils 0.8.16",
  "derive_more",
- "digest 0.10.3",
+ "digest 0.10.7",
  "either",
  "flate2",
- "flume",
  "futures 0.3.26",
  "futures-channel",
  "futures-core",
  "futures-executor",
  "futures-io",
  "futures-sink",
- "futures-task",
  "futures-util",
  "generic-array",
  "getrandom 0.1.16",
  "getrandom 0.2.8",
  "hashbrown 0.12.3",
+ "hashbrown 0.14.2",
+ "heck 0.4.1",
  "hmac 0.12.1",
  "hyper",
- "indexmap",
  "lazy_static",
  "libc",
  "log",
  "memchr",
  "miniz_oxide",
+ "mio 0.8.9",
  "native-tls",
- "num-bigint 0.4.3",
  "num-integer",
  "num-iter",
  "num-traits",
@@ -3975,7 +4071,7 @@ dependencies = [
  "openssl-sys",
  "parking_lot 0.12.1",
  "rand 0.8.5",
- "rand_core 0.6.2",
+ "rand_core 0.6.4",
  "regex",
  "regex-automata",
  "regex-syntax",
@@ -3986,25 +4082,27 @@ dependencies = [
  "sha2 0.10.5",
  "simd-adler32",
  "socket2 0.4.7",
+ "socket2 0.5.5",
  "sqlx",
- "sqlx-core",
  "sqlx-macros",
- "standback",
+ "sqlx-macros-core",
+ "sqlx-mysql",
+ "sqlx-sqlite",
  "syn 1.0.107",
  "syn 2.0.26",
  "time 0.3.14",
- "tokio 0.2.25",
  "tokio 1.34.0",
  "tokio-stream",
  "tokio-util 0.6.9",
  "tokio-util 0.7.4",
  "tracing",
- "tracing-core",
  "twitch_oauth2",
  "unicode-bidi",
  "unicode-normalization",
  "url",
  "void",
+ "winapi 0.3.9",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4445,7 +4543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core 0.6.2",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -4461,7 +4559,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.7",
  "hmac 0.12.1",
  "password-hash",
  "sha2 0.10.5",
@@ -4469,9 +4567,9 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.3.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
@@ -4596,24 +4694,23 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.3.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
  "der",
  "pkcs8",
- "zeroize",
+ "spki",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
- "zeroize",
 ]
 
 [[package]]
@@ -4818,7 +4915,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
- "rand_core 0.6.2",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4838,7 +4935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.2",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4867,9 +4964,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.8",
 ]
@@ -5151,20 +5248,20 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.6.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
+checksum = "86ef35bf3e7fe15a53c4ab08a998e42271eab13eb0db224126bc7bc4c4bad96d"
 dependencies = [
- "byteorder",
- "digest 0.10.3",
+ "const-oid",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
- "num-iter",
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core 0.6.2",
- "smallvec 1.10.0",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -5635,7 +5732,7 @@ checksum = "006769ba83e921b3085caa8334186b00cf92b4cb1a6cf4632fbccc8eff5c7549"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures 0.2.5",
- "digest 0.10.3",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5659,7 +5756,7 @@ checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures 0.2.5",
- "digest 0.10.3",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5669,6 +5766,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5781,18 +5888,18 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api 0.4.6",
 ]
 
 [[package]]
 name = "spki"
-version = "0.5.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
  "der",
@@ -5811,70 +5918,77 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.6.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9249290c05928352f71c077cc44a464d880c63f26f7534728cca008e135c0428"
+checksum = "0e50c216e3624ec8e7ecd14c6a6a6370aad6ee5d8cfc3ab30b5162eeeef2ed33"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
 ]
 
 [[package]]
 name = "sqlx-core"
-version = "0.6.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
+checksum = "8d6753e460c998bbd4cd8c6f0ed9a64346fcca0723d6e75e52fdc351c5d2169d"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.8.3",
  "atoi",
- "bitflags 1.3.2",
  "byteorder",
  "bytes 1.3.0",
  "chrono",
  "crc",
  "crossbeam-queue",
- "digest 0.10.3",
  "dotenvy",
  "either",
  "event-listener",
- "flume",
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-intrusive",
+ "futures-io",
  "futures-util",
- "generic-array",
  "hashlink",
  "hex",
- "indexmap",
- "itoa 1.0.3",
- "libc",
- "libsqlite3-sys",
+ "indexmap 2.1.0",
  "log",
  "memchr",
- "num-bigint 0.4.3",
+ "native-tls",
  "once_cell",
  "paste",
  "percent-encoding",
- "rand 0.8.5",
- "rsa",
  "serde",
- "sha1 0.10.4",
+ "serde_json",
  "sha2 0.10.5",
  "smallvec 1.10.0",
  "sqlformat",
- "sqlx-rt",
- "stringprep",
  "thiserror",
+ "tokio 1.34.0",
  "tokio-stream",
+ "tracing",
  "url",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.6.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b850fa514dc11f2ee85be9d055c512aa866746adfacd1cb42d867d68e6a5b0d9"
+checksum = "9a793bb3ba331ec8359c1853bd39eed32cdd7baaf22c35ccf5c92a7e8d1189ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4ee1e104e00dedb6aa5ffdd1343107b0a4702e862a84320ee7cc74782d96fc"
 dependencies = [
  "dotenvy",
  "either",
@@ -5887,21 +6001,119 @@ dependencies = [
  "serde_json",
  "sha2 0.10.5",
  "sqlx-core",
- "sqlx-rt",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
  "syn 1.0.107",
+ "tempfile",
+ "tokio 1.34.0",
  "url",
 ]
 
 [[package]]
-name = "sqlx-rt"
-version = "0.6.2"
+name = "sqlx-mysql"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c5b2d25fa654cc5f841750b8e1cdedbe21189bf9a9382ee90bfa9dd3562396"
+checksum = "864b869fdf56263f4c95c45483191ea0af340f9f3e3e7b4d57a61c7c87a970db"
 dependencies = [
- "native-tls",
+ "atoi",
+ "base64 0.21.0",
+ "bitflags 2.4.0",
+ "byteorder",
+ "bytes 1.3.0",
+ "chrono",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "itoa 1.0.3",
+ "log",
+ "md-5 0.10.6",
+ "memchr",
  "once_cell",
- "tokio 1.34.0",
- "tokio-native-tls",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1 0.10.4",
+ "sha2 0.10.5",
+ "smallvec 1.10.0",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7ae0e6a97fb3ba33b23ac2671a5ce6e3cabe003f451abd5a56e7951d975624"
+dependencies = [
+ "atoi",
+ "base64 0.21.0",
+ "bitflags 2.4.0",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "home",
+ "itoa 1.0.3",
+ "log",
+ "md-5 0.10.6",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha1 0.10.4",
+ "sha2 0.10.5",
+ "smallvec 1.10.0",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59dc83cf45d89c555a577694534fcd1b55c545a816c816ce51f20bbe56a4f3f"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume 0.11.0",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -6052,7 +6264,7 @@ dependencies = [
  "log",
  "lru_time_cache",
  "magic-crypt",
- "md-5",
+ "md-5 0.9.1",
  "media",
  "memory_caching",
  "mimetypes",
@@ -6607,7 +6819,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
 dependencies = [
  "bytes 0.5.6",
- "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
@@ -6859,7 +7070,19 @@ dependencies = [
  "cfg-if 1.0.0",
  "log",
  "pin-project-lite 0.2.13",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -7048,7 +7271,7 @@ dependencies = [
  "lazy_static",
  "log",
  "magic-crypt",
- "md-5",
+ "md-5 0.9.1",
  "my-workspace-hack",
  "mysql_queries",
  "native-tls",
@@ -7287,7 +7510,7 @@ dependencies = [
  "jwt",
  "lazy_static",
  "log",
- "md-5",
+ "md-5 0.9.1",
  "my-workspace-hack",
  "mysql_queries",
  "once_cell",
@@ -7625,7 +7848,7 @@ dependencies = [
  "limitation",
  "log",
  "magic-crypt",
- "md-5",
+ "md-5 0.9.1",
  "my-workspace-hack",
  "mysql_queries",
  "native-tls",
@@ -7654,6 +7877,12 @@ name = "weezl"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
 
 [[package]]
 name = "widestring"
@@ -7703,6 +7932,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af6041b3f84485c21b57acdc0fee4f4f0c93f426053dc05fa5d6fc262537bbff"
+dependencies = [
+ "windows-targets 0.48.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/crates/_types/enums/Cargo.toml
+++ b/crates/_types/enums/Cargo.toml
@@ -21,8 +21,9 @@ serde_derive = "1.0.125"
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "sqlite", "runtime-actix-native-tls", "offline", "chrono" ] }
-sqlx-core = { version = "0.6.2" }
+sqlx = { version = "0.7.2", features = [ "mysql", "sqlite", "runtime-tokio-native-tls", "chrono" ] }
+sqlx-core = { version = "0.7.2" }
+sqlx-mysql= { version = "0.7.2" }
 my-workspace-hack = { version = "0.1", path = "../../../my-workspace-hack" }
 
 [dev-dependencies]

--- a/crates/_types/enums/src/macros/impl_mysql_enum_coders.rs
+++ b/crates/_types/enums/src/macros/impl_mysql_enum_coders.rs
@@ -12,20 +12,20 @@
 macro_rules! impl_mysql_enum_coders {
   ($t:ident) => {
 
-    impl sqlx::Type<sqlx_core::mysql::MySql> for $t {
-      fn type_info() -> sqlx_core::mysql::MySqlTypeInfo {
+    impl sqlx::Type<sqlx::MySql> for $t {
+      fn type_info() -> sqlx_mysql::MySqlTypeInfo {
         // // 0.4.x series:
         // String::type_info()
 
         // NB: https://docs.rs/sqlx-core/0.6.2/src/sqlx_core/mysql/types/uuid.rs.html#38-66 serves as an example
-        <str as sqlx::Type<sqlx_core::mysql::MySql>>::type_info()
+        <str as sqlx::Type<sqlx::MySql>>::type_info()
       }
     }
 
-    impl<'q> sqlx::Encode<'q, sqlx_core::mysql::MySql> for $t {
+    impl<'q> sqlx::Encode<'q, sqlx::MySql> for $t {
       fn encode_by_ref(
         &self,
-        buf: &mut <sqlx_core::mysql::MySql as sqlx_core::database::HasArguments<'q>>::ArgumentBuffer
+        buf: &mut <sqlx::MySql as sqlx_core::database::HasArguments<'q>>::ArgumentBuffer
       ) -> sqlx_core::encode::IsNull {
         // // 0.4.x series:
         // // NB: In the absence of `#[derive(sqlx::Type)]` and `#sqlx(rename_all="lowercase")]`,
@@ -35,13 +35,13 @@ macro_rules! impl_mysql_enum_coders {
         // NB: https://docs.rs/sqlx-core/0.6.2/src/sqlx_core/mysql/types/uuid.rs.html#38-66 and
         //  https://docs.rs/sqlx-core/0.6.2/src/sqlx_core/mysql/types/str.rs.html#75-78 serves as examples
         let value = self.to_str();
-        <&str as sqlx::Encode<sqlx_core::mysql::MySql>>::encode(&*value, buf)
+        <&str as sqlx::Encode<sqlx::MySql>>::encode(&*value, buf)
       }
     }
 
-    impl<'r> sqlx::Decode<'r, sqlx_core::mysql::MySql> for $t {
+    impl<'r> sqlx::Decode<'r, sqlx::MySql> for $t {
       fn decode(
-        value: sqlx_core::mysql::MySqlValueRef<'r>,
+        value: sqlx_mysql::MySqlValueRef<'r>,
       ) -> Result<Self, sqlx_core::error::BoxDynError> {
         // // 0.4.x series:
         // let string = String::decode(value)?;
@@ -50,7 +50,7 @@ macro_rules! impl_mysql_enum_coders {
 
         // NB: https://docs.rs/sqlx-core/0.6.2/src/sqlx_core/mysql/types/uuid.rs.html#38-66 serves as an example
         // delegate to the &str type to decode from MySQL
-        let text = <&str as sqlx::Decode<sqlx_core::mysql::MySql>>::decode(value)?;
+        let text = <&str as sqlx::Decode<sqlx::MySql>>::decode(value)?;
         let value = $t::from_str(&text)?;
         Ok(value)
       }

--- a/crates/_types/enums/src/macros/impl_sqlite_enum_coders.rs
+++ b/crates/_types/enums/src/macros/impl_sqlite_enum_coders.rs
@@ -12,36 +12,37 @@
 macro_rules! impl_sqlite_enum_coders {
   ($t:ident) => {
 
-    impl sqlx::Type<sqlx_core::sqlite::Sqlite> for $t {
-      fn type_info() -> sqlx_core::sqlite::SqliteTypeInfo {
-        // NB: https://docs.rs/sqlx-core/0.6.2/src/sqlx_core/mysql/types/uuid.rs.html#38-66 serves as an example
-        <str as sqlx::Type<sqlx_core::sqlite::Sqlite>>::type_info()
-      }
-    }
+    // TODO(bt,2023-11-19): We're not using sqlite anymore. Consider removing this.
+    //impl sqlx::Type<sqlx_core::sqlite::Sqlite> for $t {
+    //  fn type_info() -> sqlx_core::sqlite::SqliteTypeInfo {
+    //    // NB: https://docs.rs/sqlx-core/0.6.2/src/sqlx_core/mysql/types/uuid.rs.html#38-66 serves as an example
+    //    <str as sqlx::Type<sqlx_core::sqlite::Sqlite>>::type_info()
+    //  }
+    //}
 
-    impl<'q> sqlx::Encode<'q, sqlx_core::sqlite::Sqlite> for $t {
-      fn encode_by_ref(
-        &self,
-        buf: &mut <sqlx_core::sqlite::Sqlite as sqlx_core::database::HasArguments<'q>>::ArgumentBuffer
-      ) -> sqlx_core::encode::IsNull {
-        // NB: https://docs.rs/sqlx-core/0.6.2/src/sqlx_core/mysql/types/uuid.rs.html#38-66 and
-        //  https://docs.rs/sqlx-core/0.6.2/src/sqlx_core/mysql/types/str.rs.html#75-78 serves as examples
-        let value = self.to_str();
-        <&str as sqlx::Encode<sqlx_core::sqlite::Sqlite>>::encode(&*value, buf)
-      }
-    }
+    //impl<'q> sqlx::Encode<'q, sqlx_core::sqlite::Sqlite> for $t {
+    //  fn encode_by_ref(
+    //    &self,
+    //    buf: &mut <sqlx_core::sqlite::Sqlite as sqlx_core::database::HasArguments<'q>>::ArgumentBuffer
+    //  ) -> sqlx_core::encode::IsNull {
+    //    // NB: https://docs.rs/sqlx-core/0.6.2/src/sqlx_core/mysql/types/uuid.rs.html#38-66 and
+    //    //  https://docs.rs/sqlx-core/0.6.2/src/sqlx_core/mysql/types/str.rs.html#75-78 serves as examples
+    //    let value = self.to_str();
+    //    <&str as sqlx::Encode<sqlx_core::sqlite::Sqlite>>::encode(&*value, buf)
+    //  }
+    //}
 
-    impl<'r> sqlx::Decode<'r, sqlx_core::sqlite::Sqlite> for $t {
-      fn decode(
-        value: sqlx_core::sqlite::SqliteValueRef<'r>,
-      ) -> Result<Self, sqlx_core::error::BoxDynError> {
-        // NB: https://docs.rs/sqlx-core/0.6.2/src/sqlx_core/mysql/types/uuid.rs.html#38-66 serves as an example
-        // delegate to the &str type to decode from MySQL
-        let text = <&str as sqlx::Decode<sqlx_core::sqlite::Sqlite>>::decode(value)?;
-        let value = $t::from_str(&text)?;
-        Ok(value)
-      }
-    }
+    //impl<'r> sqlx::Decode<'r, sqlx_core::sqlite::Sqlite> for $t {
+    //  fn decode(
+    //    value: sqlx_core::sqlite::SqliteValueRef<'r>,
+    //  ) -> Result<Self, sqlx_core::error::BoxDynError> {
+    //    // NB: https://docs.rs/sqlx-core/0.6.2/src/sqlx_core/mysql/types/uuid.rs.html#38-66 serves as an example
+    //    // delegate to the &str type to decode from MySQL
+    //    let text = <&str as sqlx::Decode<sqlx_core::sqlite::Sqlite>>::decode(value)?;
+    //    let value = $t::from_str(&text)?;
+    //    Ok(value)
+    //  }
+    //}
 
   }
 }

--- a/crates/_types/reusable_types/Cargo.toml
+++ b/crates/_types/reusable_types/Cargo.toml
@@ -18,14 +18,14 @@ path = "src/lib.rs"
 # (none)
 
 # External
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 
 # Serialization
 serde = "1.0.125"
 serde_derive = "1.0.125"
 
 # MySql Database
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 my-workspace-hack = { version = "0.1", path = "../../../my-workspace-hack" }
 
 [dev-dependencies]

--- a/crates/_types/tokens/Cargo.toml
+++ b/crates/_types/tokens/Cargo.toml
@@ -24,8 +24,8 @@ rand = "0.8.3"
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
-sqlx-core = { version = "0.6.2" }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
+sqlx-core = { version = "0.7.2" }
 my-workspace-hack = { version = "0.1", path = "../../../my-workspace-hack" }
 
 [dev-dependencies]

--- a/crates/cli/dev_database_seed/Cargo.toml
+++ b/crates/cli/dev_database_seed/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { version = "1.6.0", features = ["macros"] }
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 
 elasticsearch = "8.5.0-alpha.1"
 my-workspace-hack = { version = "0.1", path = "../../../my-workspace-hack" }

--- a/crates/cli/dev_upload_media_file/Cargo.toml
+++ b/crates/cli/dev_upload_media_file/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1.6.0", features = ["macros"] }
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 my-workspace-hack = { version = "0.1", path = "../../../my-workspace-hack" }
 
 [dev-dependencies]

--- a/crates/cli/elasticsearch-cli/Cargo.toml
+++ b/crates/cli/elasticsearch-cli/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1.6.0", features = ["macros"] }
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 
 elasticsearch = "8.5.0-alpha.1"
 

--- a/crates/lib/api_clients/fakeyou_client/Cargo.toml
+++ b/crates/lib/api_clients/fakeyou_client/Cargo.toml
@@ -20,7 +20,7 @@ tokens = { path = "../../../_types/tokens" }
 
 # External
 bytes = "1.3"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 log = "0.4.14"
 once_cell = "1.9.0"
 

--- a/crates/lib/datetimes/Cargo.toml
+++ b/crates/lib/datetimes/Cargo.toml
@@ -13,7 +13,7 @@ name = "datetimes"
 path = "src/lib.rs"
 
 [dependencies]
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 once_cell = "1.18.0"
 my-workspace-hack = { version = "0.1", path = "../../../my-workspace-hack" }
 

--- a/crates/lib/deprecated/http_server_common/Cargo.toml
+++ b/crates/lib/deprecated/http_server_common/Cargo.toml
@@ -21,7 +21,7 @@ reusable_types = { path = "../../../_types/reusable_types" }
 # External
 anyhow = "1.0.75"
 base64 = "0.21.0"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 log = "0.4.14"
 once_cell = "1.18.0"
 regex = "1.5.4"

--- a/crates/lib/elasticsearch_schema/Cargo.toml
+++ b/crates/lib/elasticsearch_schema/Cargo.toml
@@ -23,7 +23,7 @@ elasticsearch = "8.5.0-alpha.1"
 log = "0.4.14"
 
 # Serialization
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.108"
 my-workspace-hack = { version = "0.1", path = "../../../my-workspace-hack" }

--- a/crates/lib/jobs_common/Cargo.toml
+++ b/crates/lib/jobs_common/Cargo.toml
@@ -24,7 +24,7 @@ redis_common = { path = "../redis_common" }
 
 # External
 anyhow = "1.0.75"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 log = "0.4.14"
 r2d2_redis = "0.14.0"
 my-workspace-hack = { version = "0.1", path = "../../../my-workspace-hack" }

--- a/crates/lib/mysql_queries/Cargo.toml
+++ b/crates/lib/mysql_queries/Cargo.toml
@@ -25,7 +25,7 @@ tokens = { path = "../../_types/tokens" }
 
 # External
 anyhow = "1.0.75"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 dotenv = "0.15.0"
 log = "0.4.14"
 
@@ -43,6 +43,6 @@ toml = "0.5.8"
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 my-workspace-hack = { version = "0.1", path = "../../../my-workspace-hack" }
 

--- a/crates/lib/mysql_queries/src/queries/email_sender_jobs/list_available_email_sender_jobs.rs
+++ b/crates/lib/mysql_queries/src/queries/email_sender_jobs/list_available_email_sender_jobs.rs
@@ -230,7 +230,7 @@ FROM email_sender_jobs"#.to_string();
   LIMIT ?
         "#);
 
-  let mut query = sqlx::query_as::<_, AvailableEmailSenderJobRawInternal>(&query)
+  let query = sqlx::query_as::<_, AvailableEmailSenderJobRawInternal>(&query)
       .bind(args.is_debug_worker)
       .bind(args.num_records);
 

--- a/crates/lib/mysql_queries/src/queries/email_sender_jobs/mark_email_sender_job_pending_and_grab_lock.rs
+++ b/crates/lib/mysql_queries/src/queries/email_sender_jobs/mark_email_sender_job_pending_and_grab_lock.rs
@@ -38,7 +38,7 @@ FOR UPDATE
         "#,
         job_id.0,
     )
-      .fetch_one(&mut transaction)
+      .fetch_one(&mut *transaction)
       .await;
 
   let record : EmailSenderJobLockRecord = match maybe_record {
@@ -89,7 +89,7 @@ WHERE id = ?
         &container_environment.cluster_name,
         job_id.0,
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await?;
   } else {
     let _acquire_lock = sqlx::query!(
@@ -107,7 +107,7 @@ WHERE id = ?
         &container_environment.cluster_name,
         job_id.0,
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await?;
   }
 

--- a/crates/lib/mysql_queries/src/queries/generic_download/job/list_available_generic_download_jobs.rs
+++ b/crates/lib/mysql_queries/src/queries/generic_download/job/list_available_generic_download_jobs.rs
@@ -90,7 +90,7 @@ WHERE
     LIMIT {}
   "#, num_records));
 
-  let mut job_records = sqlx::query_as::<_, AvailableDownloadJobRawInternal>(&query)
+  let job_records = sqlx::query_as::<_, AvailableDownloadJobRawInternal>(&query)
       .fetch_all(pool)
       .await?;
 

--- a/crates/lib/mysql_queries/src/queries/generic_download/job/mark_generic_download_job_pending_and_grab_lock.rs
+++ b/crates/lib/mysql_queries/src/queries/generic_download/job/mark_generic_download_job_pending_and_grab_lock.rs
@@ -38,7 +38,7 @@ FOR UPDATE
         "#,
         job_id.0,
     )
-      .fetch_one(&mut transaction)
+      .fetch_one(&mut *transaction)
       .await;
 
   let record : GenericDownloadJobLockRecord = match maybe_record {
@@ -87,7 +87,7 @@ WHERE id = ?
         &container_environment.cluster_name,
         job_id.0,
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await?;
   } else {
     let _acquire_lock = sqlx::query!(
@@ -105,7 +105,7 @@ WHERE id = ?
         &container_environment.cluster_name,
         job_id.0,
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await?;
   }
 

--- a/crates/lib/mysql_queries/src/queries/generic_inference/job/list_available_generic_inference_jobs.rs
+++ b/crates/lib/mysql_queries/src/queries/generic_inference/job/list_available_generic_inference_jobs.rs
@@ -242,7 +242,7 @@ FROM generic_inference_jobs"#.to_string();
   LIMIT ?
         "#);
 
-  let mut query = sqlx::query_as::<_, AvailableInferenceJobRawInternal>(&query)
+  let query = sqlx::query_as::<_, AvailableInferenceJobRawInternal>(&query)
       .bind(args.is_debug_worker)
       .bind(args.num_records);
 

--- a/crates/lib/mysql_queries/src/queries/generic_inference/job/mark_generic_inference_job_cancelled_by_user.rs
+++ b/crates/lib/mysql_queries/src/queries/generic_inference/job/mark_generic_inference_job_cancelled_by_user.rs
@@ -23,7 +23,7 @@ AND status NOT IN ('complete_success', 'complete_failure', 'dead', 'cancelled_by
         "#,
         job_token,
     )
-      .execute(mysql_connection)
+      .execute(&mut **mysql_connection)
       .await;
 
   match query_result {

--- a/crates/lib/mysql_queries/src/queries/generic_inference/job/mark_generic_inference_job_completely_failed.rs
+++ b/crates/lib/mysql_queries/src/queries/generic_inference/job/mark_generic_inference_job_completely_failed.rs
@@ -14,14 +14,14 @@ pub async fn mark_generic_inference_job_completely_failed(
   maybe_frontend_failure_category: Option<FrontendFailureCategory>,
 ) -> AnyhowResult<()>
 {
-  let mut maybe_public_failure_reason
+  let maybe_public_failure_reason
       = maybe_public_failure_reason.map(|reason| {
         let mut reason = reason.trim().to_string();
         reason.truncate(512); // Max length of column is 512
         reason
       });
 
-  let mut maybe_internal_debugging_failure_reason
+  let maybe_internal_debugging_failure_reason
       = maybe_internal_debugging_failure_reason.map(|reason| {
         let mut reason = reason.trim().to_string();
         reason.truncate(512); // Max length of column is 512

--- a/crates/lib/mysql_queries/src/queries/generic_inference/job/mark_generic_inference_job_pending_and_grab_lock.rs
+++ b/crates/lib/mysql_queries/src/queries/generic_inference/job/mark_generic_inference_job_pending_and_grab_lock.rs
@@ -38,7 +38,7 @@ FOR UPDATE
         "#,
         job_id.0,
     )
-      .fetch_one(&mut transaction)
+      .fetch_one(&mut *transaction)
       .await;
 
   let record : GenericInferenceJobLockRecord = match maybe_record {
@@ -89,7 +89,7 @@ WHERE id = ?
         &container_environment.cluster_name,
         job_id.0,
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await?;
   } else {
     let _acquire_lock = sqlx::query!(
@@ -107,7 +107,7 @@ WHERE id = ?
         &container_environment.cluster_name,
         job_id.0,
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await?;
   }
 

--- a/crates/lib/mysql_queries/src/queries/generic_inference/web/get_inference_job_status.rs
+++ b/crates/lib/mysql_queries/src/queries/generic_inference/web/get_inference_job_status.rs
@@ -154,7 +154,7 @@ WHERE jobs.token = ?
         "#,
       job_token
     )
-      .fetch_one(mysql_connection)
+      .fetch_one(&mut **mysql_connection)
       .await;
 
   let record = match maybe_status {

--- a/crates/lib/mysql_queries/src/queries/generic_synthetic_ids/transactional_increment_generic_synthetic_id.rs
+++ b/crates/lib/mysql_queries/src/queries/generic_synthetic_ids/transactional_increment_generic_synthetic_id.rs
@@ -31,7 +31,7 @@ ON DUPLICATE KEY UPDATE
       user_token,
       id_category_str
     )
-        .execute(&mut *transaction) // TODO/FIXME WTF THIS IS SO GROSS
+        .execute(&mut **transaction) // TODO/FIXME WTF THIS IS SO GROSS
         .await;
 
     match query_result {
@@ -59,7 +59,7 @@ LIMIT 1
       user_token,
       id_category_str,
     )
-      .fetch_one(&mut *transaction)
+      .fetch_one(&mut **transaction)
       .await;
 
   let record : SyntheticIdRecord = match query_result {

--- a/crates/lib/mysql_queries/src/queries/media_files/insert_media_file_from_cli_tool.rs
+++ b/crates/lib/mysql_queries/src/queries/media_files/insert_media_file_from_cli_tool.rs
@@ -86,7 +86,7 @@ SET
 
       args.creator_set_visibility.to_str(),
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await;
 
     let record_id = match query_result {

--- a/crates/lib/mysql_queries/src/queries/media_files/insert_media_file_from_face_animation.rs
+++ b/crates/lib/mysql_queries/src/queries/media_files/insert_media_file_from_face_animation.rs
@@ -136,7 +136,7 @@ SET
       args.worker_hostname,
       args.worker_cluster
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await;
 
     let record_id = match query_result {

--- a/crates/lib/mysql_queries/src/queries/media_files/insert_media_file_from_voice_conversion.rs
+++ b/crates/lib/mysql_queries/src/queries/media_files/insert_media_file_from_voice_conversion.rs
@@ -152,7 +152,7 @@ SET
       args.worker_hostname,
       args.worker_cluster
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await;
 
     let record_id = match query_result {

--- a/crates/lib/mysql_queries/src/queries/media_files/insert_media_file_from_zero_shot_tts.rs
+++ b/crates/lib/mysql_queries/src/queries/media_files/insert_media_file_from_zero_shot_tts.rs
@@ -136,7 +136,7 @@ pub async fn insert_media_file_from_zero_shot(
           args.worker_hostname,
           args.worker_cluster
         )
-            .execute(&mut transaction)
+            .execute(&mut *transaction)
             .await;
     
         let record_id = match query_result {

--- a/crates/lib/mysql_queries/src/queries/media_uploads/get_media_upload_by_uuid.rs
+++ b/crates/lib/mysql_queries/src/queries/media_uploads/get_media_upload_by_uuid.rs
@@ -61,7 +61,7 @@ WHERE
         "#,
     uuid_idempotency_token,
   )
-      .fetch_one(mysql_connection)
+      .fetch_one(&mut **mysql_connection)
       .await;
 
   match maybe_result {

--- a/crates/lib/mysql_queries/src/queries/media_uploads/get_media_upload_for_inference.rs
+++ b/crates/lib/mysql_queries/src/queries/media_uploads/get_media_upload_for_inference.rs
@@ -69,7 +69,7 @@ WHERE
         "#,
     media_upload_token.as_str(),
   )
-      .fetch_one(mysql_connection)
+      .fetch_one(&mut **mysql_connection)
       .await;
 
   match maybe_result {

--- a/crates/lib/mysql_queries/src/queries/media_uploads/insert_media_upload.rs
+++ b/crates/lib/mysql_queries/src/queries/media_uploads/insert_media_upload.rs
@@ -64,7 +64,7 @@ ON DUPLICATE KEY UPDATE
       creator_user_token,
       creator_user_token
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await;
 
     match query_result {
@@ -88,7 +88,7 @@ LIMIT 1
         "#,
       creator_user_token,
     )
-        .fetch_one(&mut transaction)
+        .fetch_one(&mut *transaction)
         .await;
 
     let record : SyntheticIdRecord = match query_result {
@@ -169,7 +169,7 @@ SET
         args.creator_set_visibility.to_str(),
     );
 
-  let query_result = query.execute(&mut transaction)
+  let query_result = query.execute(&mut *transaction)
       .await;
 
   let result_tuple  = match query_result {

--- a/crates/lib/mysql_queries/src/queries/media_uploads/reverse_list_user_media_uploads_of_type.rs
+++ b/crates/lib/mysql_queries/src/queries/media_uploads/reverse_list_user_media_uploads_of_type.rs
@@ -68,7 +68,7 @@ LIMIT 25
     creator_user_token,
     media_upload_type.to_str(),
   )
-          .fetch_all(mysql_connection)
+          .fetch_all(&mut **mysql_connection)
           .await;
 
   match maybe_results {

--- a/crates/lib/mysql_queries/src/queries/model_categories/list_categories_query_builder.rs
+++ b/crates/lib/mysql_queries/src/queries/model_categories/list_categories_query_builder.rs
@@ -184,7 +184,7 @@ impl ListCategoriesQueryBuilder {
       query = query.bind(model_type);
     }
 
-    let mut results = query.fetch_all(mysql_connection)
+    let mut results = query.fetch_all(&mut **mysql_connection)
         .await?;
 
     Ok(results)

--- a/crates/lib/mysql_queries/src/queries/trending_model_analytics/list_trending_tts_models.rs
+++ b/crates/lib/mysql_queries/src/queries/trending_model_analytics/list_trending_tts_models.rs
@@ -65,7 +65,7 @@ pub async fn list_trending_tts_models(
   let query = query_parts.join(" UNION ");
   let mut query = sqlx::query_as::<_, RawTrendingModel>(&query);
 
-  let results = query.fetch_all(mysql_connection).await?;
+  let results = query.fetch_all(&mut **mysql_connection).await?;
 
   let results = results.into_iter()
       .map(|model| TrendingModel {

--- a/crates/lib/mysql_queries/src/queries/trending_model_analytics/upsert_trending_model_analytics.rs
+++ b/crates/lib/mysql_queries/src/queries/trending_model_analytics/upsert_trending_model_analytics.rs
@@ -46,6 +46,6 @@ ON DUPLICATE KEY UPDATE
       args.numeric_value,
     );
 
-  let _r = query.execute(args.mysql_connection).await?;
+  let _r = query.execute(&mut **args.mysql_connection).await?;
   Ok(())
 }

--- a/crates/lib/mysql_queries/src/queries/tts/stats/calculate_tts_model_leaderboard.rs
+++ b/crates/lib/mysql_queries/src/queries/tts/stats/calculate_tts_model_leaderboard.rs
@@ -55,7 +55,7 @@ ORDER BY uploaded_count desc
 LIMIT 25;
         "#,
     )
-      .fetch_all(mysql_pool)
+      .fetch_all(&mut **mysql_pool)
       .await;
 
   let results : Vec<TtsLeaderboardRecordForListRaw> = match maybe_results {

--- a/crates/lib/mysql_queries/src/queries/tts/tts_category_assignments/fetch_and_build_tts_model_category_map.rs
+++ b/crates/lib/mysql_queries/src/queries/tts/tts_category_assignments/fetch_and_build_tts_model_category_map.rs
@@ -75,7 +75,7 @@ WHERE
 
         "#,
     )
-      .fetch_all(mysql_connection)
+      .fetch_all(&mut **mysql_connection)
       .await;
 
   match maybe_results {

--- a/crates/lib/mysql_queries/src/queries/tts/tts_category_assignments/list_assigned_tts_categories_query_builder.rs
+++ b/crates/lib/mysql_queries/src/queries/tts/tts_category_assignments/list_assigned_tts_categories_query_builder.rs
@@ -159,7 +159,7 @@ impl ListAssignedTtsCategoriesQueryBuilder {
     // NB: Model token is always used for scoping.
     query = query.bind(&self.scope_tts_model_token);
 
-    let mut results = query.fetch_all(mysql_connection)
+    let mut results = query.fetch_all(&mut **mysql_connection)
         .await?;
 
     Ok(results)

--- a/crates/lib/mysql_queries/src/queries/tts/tts_download_jobs/tts_download_job_queries.rs
+++ b/crates/lib/mysql_queries/src/queries/tts/tts_download_jobs/tts_download_job_queries.rs
@@ -81,7 +81,7 @@ FOR UPDATE
         "#,
         job.id,
     )
-      .fetch_one(&mut transaction)
+      .fetch_one(&mut *transaction)
       .await;
 
   let record : TtsUploadLockRecord = match maybe_record {
@@ -124,7 +124,7 @@ WHERE id = ?
         "#,
         job.id,
     )
-      .execute(&mut transaction)
+      .execute(&mut *transaction)
       .await?;
 
   transaction.commit().await?;

--- a/crates/lib/mysql_queries/src/queries/tts/tts_inference_jobs/mark_tts_inference_job_pending_and_grab_lock.rs
+++ b/crates/lib/mysql_queries/src/queries/tts/tts_inference_jobs/mark_tts_inference_job_pending_and_grab_lock.rs
@@ -34,7 +34,7 @@ FOR UPDATE
         "#,
         job_id.0,
     )
-      .fetch_one(&mut transaction)
+      .fetch_one(&mut *transaction)
       .await;
 
   let record : TtsInferenceLockRecord = match maybe_record {
@@ -77,7 +77,7 @@ WHERE id = ?
         "#,
         job_id.0,
     )
-      .execute(&mut transaction)
+      .execute(&mut *transaction)
       .await?;
 
   transaction.commit().await?;

--- a/crates/lib/mysql_queries/src/queries/tts/tts_models/count_tts_model_uses.rs
+++ b/crates/lib/mysql_queries/src/queries/tts/tts_models/count_tts_model_uses.rs
@@ -33,7 +33,7 @@ pub async fn count_tts_model_uses(
     last_n_minutes,
     tts_model_token
   )
-      .fetch_one(mysql_connection)
+      .fetch_one(&mut **mysql_connection)
       .await?;
 
   Ok(TtsModelUseCountInfo {

--- a/crates/lib/mysql_queries/src/queries/tts/tts_models/count_tts_model_uses_total.rs
+++ b/crates/lib/mysql_queries/src/queries/tts/tts_models/count_tts_model_uses_total.rs
@@ -30,7 +30,7 @@ pub async fn count_tts_model_uses_total(
         "#,
     tts_model_token
   )
-      .fetch_one(mysql_connection)
+      .fetch_one(&mut **mysql_connection)
       .await?;
 
   Ok(TtsModelTotalUseCountInfo {

--- a/crates/lib/mysql_queries/src/queries/tts/tts_models/get_tts_model.rs
+++ b/crates/lib/mysql_queries/src/queries/tts/tts_models/get_tts_model.rs
@@ -261,7 +261,7 @@ WHERE tts.token = ?
         "#,
       tts_model_token
     )
-    .fetch_one(mysql_connection)
+    .fetch_one(&mut **mysql_connection)
     .await // TODO: This will return error if it doesn't exist
 }
 
@@ -340,7 +340,7 @@ WHERE
         "#,
       tts_model_token
     )
-    .fetch_one(mysql_connection)
+    .fetch_one(&mut **mysql_connection)
     .await // TODO: This will return error if it doesn't exist
 }
 

--- a/crates/lib/mysql_queries/src/queries/tts/tts_models/list_all_tts_model_tokens.rs
+++ b/crates/lib/mysql_queries/src/queries/tts/tts_models/list_all_tts_model_tokens.rs
@@ -33,7 +33,7 @@ SELECT
     token as `token: tokens::tokens::tts_models::TtsModelToken`
 FROM tts_models
         "#)
-        .fetch_all(mysql_connection)
+        .fetch_all(&mut **mysql_connection)
         .await?;
 
   let tokens = tokens.into_iter()

--- a/crates/lib/mysql_queries/src/queries/tts/tts_models/list_tts_models.rs
+++ b/crates/lib/mysql_queries/src/queries/tts/tts_models/list_tts_models.rs
@@ -153,7 +153,7 @@ WHERE
     AND tts.user_deleted_at IS NULL
     AND tts.mod_deleted_at IS NULL
         "#)
-      .fetch_all(mysql_connection)
+      .fetch_all(&mut **mysql_connection)
       .await?
   } else {
     info!("listing tts models for everyone; all");
@@ -187,7 +187,7 @@ WHERE
     tts.user_deleted_at IS NULL
     AND tts.mod_deleted_at IS NULL
         "#)
-      .fetch_all(mysql_connection)
+      .fetch_all(&mut **mysql_connection)
       .await?
   };
 
@@ -237,7 +237,7 @@ WHERE
     AND tts.mod_deleted_at IS NULL
         "#,
       scope_creator_username)
-      .fetch_all(mysql_connection)
+      .fetch_all(&mut **mysql_connection)
       .await?
   } else {
     info!("listing tts models for user; all");
@@ -274,7 +274,7 @@ WHERE
     AND tts.mod_deleted_at IS NULL
         "#,
       scope_creator_username)
-      .fetch_all(mysql_connection)
+      .fetch_all(&mut **mysql_connection)
       .await?
   };
 

--- a/crates/lib/mysql_queries/src/queries/tts/tts_results/insert_tts_result.rs
+++ b/crates/lib/mysql_queries/src/queries/tts/tts_results/insert_tts_result.rs
@@ -99,7 +99,7 @@ ON DUPLICATE KEY UPDATE
       creator_user_token,
       creator_user_token
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await;
 
     match query_result {
@@ -123,7 +123,7 @@ LIMIT 1
         "#,
       creator_user_token,
     )
-        .fetch_one(&mut transaction)
+        .fetch_one(&mut *transaction)
         .await;
 
     let record : SyntheticIdRecord = match query_result {
@@ -191,7 +191,7 @@ SET
       worker_hostname,
       is_debug_worker,
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await;
 
     let record_id = match query_result {

--- a/crates/lib/mysql_queries/src/queries/users/user/lookup_user_for_login_by_email.rs
+++ b/crates/lib/mysql_queries/src/queries/users/user/lookup_user_for_login_by_email.rs
@@ -14,7 +14,7 @@ SELECT
   token as `token: tokens::tokens::users::UserToken`,
   username,
   email_address,
-  password_hash,
+  password_hash as `password_hash: crate::queries::users::user::lookup_user_for_login_result::VecBytes`,
   password_version,
   is_banned
 FROM users

--- a/crates/lib/mysql_queries/src/queries/users/user/lookup_user_for_login_by_username.rs
+++ b/crates/lib/mysql_queries/src/queries/users/user/lookup_user_for_login_by_username.rs
@@ -14,7 +14,7 @@ SELECT
   token as `token: tokens::tokens::users::UserToken`,
   username,
   email_address,
-  password_hash,
+  password_hash as `password_hash: crate::queries::users::user::lookup_user_for_login_result::VecBytes`,
   password_version,
   is_banned
 FROM users

--- a/crates/lib/mysql_queries/src/queries/users/user/lookup_user_for_login_result.rs
+++ b/crates/lib/mysql_queries/src/queries/users/user/lookup_user_for_login_result.rs
@@ -1,12 +1,16 @@
 use tokens::tokens::users::UserToken;
 
+// NB: Upgrade to sqlx 0.7 broke deserialization of Vec<u8>:
+// https://github.com/launchbadge/sqlx/issues/2875
+pub type VecBytes = Vec<u8>;
+
 /// Shared result type for user lookups for login (via email or username)
 #[derive(Debug)]
 pub struct UserRecordForLogin {
   pub token: UserToken,
   pub username: String,
   pub email_address: String,
-  pub password_hash: Vec<u8>,
+  pub password_hash: VecBytes,
   pub password_version: u32,
   pub is_banned: i8,
 }

--- a/crates/lib/mysql_queries/src/queries/users/user_badges/list_user_badges.rs
+++ b/crates/lib/mysql_queries/src/queries/users/user_badges/list_user_badges.rs
@@ -47,7 +47,7 @@ WHERE
         "#,
         user_token
       )
-      .fetch_all(mysql_connector)
+      .fetch_all(&mut **mysql_connector)
       .await;
 
   let user_badges : Vec<RawDbUserBadgeForList> = match maybe_user_badges {

--- a/crates/lib/mysql_queries/src/queries/users/user_password_resets/change_password_from_password_reset.rs
+++ b/crates/lib/mysql_queries/src/queries/users/user_password_resets/change_password_from_password_reset.rs
@@ -35,7 +35,7 @@ LIMIT 1
         args.user_token,
     );
 
-  let query_result = query.execute(&mut args.mysql_transaction).await;
+  let query_result = query.execute(&mut *args.mysql_transaction).await;
 
   if let Err(err) = query_result {
     let _r = args.mysql_transaction.rollback().await.ok();
@@ -57,7 +57,7 @@ LIMIT 1
         args.password_reset_token,
     );
 
-  let query_result = query.execute(&mut args.mysql_transaction).await;
+  let query_result = query.execute(&mut *args.mysql_transaction).await;
 
   if let Err(err) = query_result {
     let _r = args.mysql_transaction.rollback().await.ok();

--- a/crates/lib/mysql_queries/src/queries/users/user_password_resets/lookup_password_reset_request.rs
+++ b/crates/lib/mysql_queries/src/queries/users/user_password_resets/lookup_password_reset_request.rs
@@ -39,7 +39,7 @@ FOR UPDATE
         "#,
         password_reset_token,
     )
-      .fetch_one(&mut transaction)
+      .fetch_one(&mut *transaction)
       .await;
 
   match result {

--- a/crates/lib/mysql_queries/src/queries/users/user_profiles/get_user_profile_by_username.rs
+++ b/crates/lib/mysql_queries/src/queries/users/user_profiles/get_user_profile_by_username.rs
@@ -128,7 +128,7 @@ WHERE
         "#,
         username,
     )
-      .fetch_one(connection)
+      .fetch_one(&mut **connection)
       .await;
 
   let profile_record : RawUserProfileRecord = match maybe_profile_record {

--- a/crates/lib/mysql_queries/src/queries/users/user_ratings/get_user_rating.rs
+++ b/crates/lib/mysql_queries/src/queries/users/user_ratings/get_user_rating.rs
@@ -47,7 +47,7 @@ LIMIT 1
       entity_type,
       entity_token,
     )
-      .fetch_one(args.mysql_connection)
+      .fetch_one(&mut **args.mysql_connection)
       .await;
 
   match maybe_result {

--- a/crates/lib/mysql_queries/src/queries/users/user_ratings/update_tts_model_ratings.rs
+++ b/crates/lib/mysql_queries/src/queries/users/user_ratings/update_tts_model_ratings.rs
@@ -47,6 +47,6 @@ LIMIT 1
       token
     );
 
-  let _r = query.execute(mysql_connection).await?;
+  let _r = query.execute(&mut** mysql_connection).await?;
   Ok(())
 }

--- a/crates/lib/mysql_queries/src/queries/users/user_ratings/upsert_user_rating.rs
+++ b/crates/lib/mysql_queries/src/queries/users/user_ratings/upsert_user_rating.rs
@@ -45,6 +45,6 @@ ON DUPLICATE KEY UPDATE
       args.ip_address
     );
 
-  let _r = query.execute(args.mysql_connection).await?;
+  let _r = query.execute(&mut **args.mysql_connection).await?;
   Ok(())
 }

--- a/crates/lib/mysql_queries/src/queries/users/user_sessions/delete_user_session.rs
+++ b/crates/lib/mysql_queries/src/queries/users/user_sessions/delete_user_session.rs
@@ -3,7 +3,7 @@ use sqlx::MySqlPool;
 use errors::AnyhowResult;
 
 pub async fn delete_user_session(session_token: &str, mysql_pool: &MySqlPool) -> AnyhowResult<()> {
-  let query_result = sqlx::query!(
+  let _query_result = sqlx::query!(
         r#"
 UPDATE user_sessions
 SET deleted_at = CURRENT_TIMESTAMP()

--- a/crates/lib/mysql_queries/src/queries/users/user_sessions/get_user_session_by_token.rs
+++ b/crates/lib/mysql_queries/src/queries/users/user_sessions/get_user_session_by_token.rs
@@ -81,7 +81,7 @@ pub async fn get_user_session_by_token_pooled_connection(
   mysql_connection: &mut PoolConnection<MySql>,
   session_token: &str,
 ) -> AnyhowResult<Option<SessionUserRecord>> {
-  get_user_session_by_token(mysql_connection, session_token).await
+  get_user_session_by_token(&mut **mysql_connection, session_token).await
 }
 
 

--- a/crates/lib/mysql_queries/src/queries/users/user_subscriptions/insert_unsubscribe_reason.rs
+++ b/crates/lib/mysql_queries/src/queries/users/user_subscriptions/insert_unsubscribe_reason.rs
@@ -48,7 +48,7 @@ SET
       self.ip_address,
       );
 
-    let query_result = query.execute(mysql_connection)
+    let query_result = query.execute(&mut **mysql_connection)
         .await;
 
     let _record_id = match query_result {

--- a/crates/lib/mysql_queries/src/queries/users/user_subscriptions/list_active_user_subscriptions.rs
+++ b/crates/lib/mysql_queries/src/queries/users/user_subscriptions/list_active_user_subscriptions.rs
@@ -44,7 +44,7 @@ WHERE
         "#,
       user_token,
     )
-        .fetch_all(mysql_connection)
+        .fetch_all(&mut **mysql_connection)
         .await?;
 
     let records = records.into_iter()

--- a/crates/lib/mysql_queries/src/queries/voice_conversion/model_info_lite/get_voice_conversion_model_info_lite.rs
+++ b/crates/lib/mysql_queries/src/queries/voice_conversion/model_info_lite/get_voice_conversion_model_info_lite.rs
@@ -33,7 +33,7 @@ WHERE vc.token = ?
         "#,
     token
   )
-          .fetch_one(mysql_connection)
+          .fetch_one(&mut **mysql_connection)
           .await;
 
   let model : RawVoiceConversionModelInfoLite = match maybe_model {

--- a/crates/lib/mysql_queries/src/queries/voice_conversion/model_info_lite/list_voice_conversion_model_info_lite.rs
+++ b/crates/lib/mysql_queries/src/queries/voice_conversion/model_info_lite/list_voice_conversion_model_info_lite.rs
@@ -26,7 +26,7 @@ SELECT
     vc.model_type as `model_type: enums::by_table::voice_conversion_models::voice_conversion_model_type::VoiceConversionModelType`
 FROM voice_conversion_models as vc
         "#)
-          .fetch_all(mysql_connection)
+          .fetch_all(&mut **mysql_connection)
           .await?;
 
   Ok(models.into_iter()

--- a/crates/lib/mysql_queries/src/queries/voice_conversion/models/list_voice_conversion_models.rs
+++ b/crates/lib/mysql_queries/src/queries/voice_conversion/models/list_voice_conversion_models.rs
@@ -129,7 +129,7 @@ WHERE
     vc.user_deleted_at IS NULL
     AND vc.mod_deleted_at IS NULL
         "#)
-      .fetch_all(mysql_connection)
+      .fetch_all(&mut **mysql_connection)
       .await?)
 }
 
@@ -163,7 +163,7 @@ WHERE
     AND vc.mod_deleted_at IS NULL
         "#,
       scope_creator_username)
-      .fetch_all(mysql_connection)
+      .fetch_all(&mut **mysql_connection)
       .await?)
 }
 

--- a/crates/lib/mysql_queries/src/queries/voice_conversion/results/insert_voice_conversion_result.rs
+++ b/crates/lib/mysql_queries/src/queries/voice_conversion/results/insert_voice_conversion_result.rs
@@ -50,7 +50,7 @@ ON DUPLICATE KEY UPDATE
       creator_user_token,
       creator_user_token
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await;
 
     match query_result {
@@ -74,7 +74,7 @@ LIMIT 1
         "#,
       creator_user_token,
     )
-        .fetch_one(&mut transaction)
+        .fetch_one(&mut *transaction)
         .await;
 
     let record : SyntheticIdRecord = match query_result {
@@ -89,10 +89,6 @@ LIMIT 1
     let next_id = record.next_id as u64;
     maybe_creator_synthetic_id = Some(next_id);
   }
-
-  let vc_model_token = args.job.maybe_model_token.as_deref();
-  let creator_ip_address = args.job.creator_ip_address.as_str();
-  let creator_set_visibility = args.job.creator_set_visibility.clone();
 
   let record_id = {
     let query_result = sqlx::query!(
@@ -146,7 +142,7 @@ SET
       args.worker_cluster,
       args.is_debug_worker,
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await;
 
     let record_id = match query_result {

--- a/crates/lib/mysql_queries/src/queries/voice_designer/datasets/get_dataset.rs
+++ b/crates/lib/mysql_queries/src/queries/voice_designer/datasets/get_dataset.rs
@@ -102,7 +102,7 @@ async fn select_include_deleted(
             "#,
         dataset_token.as_str()
   )
-      .fetch_one(mysql_connection).await
+      .fetch_one(&mut **mysql_connection).await
 }
 
 async fn select_without_deleted(
@@ -129,7 +129,7 @@ async fn select_without_deleted(
             "#,
         dataset_token.as_str()
   )
-      .fetch_one(mysql_connection).await
+      .fetch_one(&mut **mysql_connection).await
 }
 #[derive(Serialize)]
 pub struct RawDataset {

--- a/crates/lib/mysql_queries/src/queries/voice_designer/datasets/list_datasets_by_username.rs
+++ b/crates/lib/mysql_queries/src/queries/voice_designer/datasets/list_datasets_by_username.rs
@@ -119,7 +119,7 @@ async fn list_datasets_by_creator_username(
             AND zd.mod_deleted_at IS NULL
         "#,
       creator_username)
-            .fetch_all(mysql_connection)
+            .fetch_all(&mut **mysql_connection)
             .await?
     } else {
         info!("listing datasets for user");
@@ -146,7 +146,7 @@ async fn list_datasets_by_creator_username(
             users.username = ?
         "#,
       creator_username)
-            .fetch_all(mysql_connection)
+            .fetch_all(&mut **mysql_connection)
             .await?
     };
 

--- a/crates/lib/mysql_queries/src/queries/voice_designer/voice_samples/get_dataset_sample.rs
+++ b/crates/lib/mysql_queries/src/queries/voice_designer/voice_samples/get_dataset_sample.rs
@@ -84,7 +84,7 @@ async fn select_include_deleted(
         "#,
         dataset_sample_token.as_str()
   )
-      .fetch_one(mysql_connection).await
+      .fetch_one(&mut **mysql_connection).await
 }
 
 async fn select_without_deleted(
@@ -106,7 +106,7 @@ async fn select_without_deleted(
         "#,
         dataset_sample_token.as_str()
   )
-      .fetch_one(mysql_connection).await
+      .fetch_one(&mut **mysql_connection).await
 }
 #[derive(Serialize)]
 pub struct RawDataset {

--- a/crates/lib/mysql_queries/src/queries/voice_designer/voice_samples/get_dataset_sample_by_uuid.rs
+++ b/crates/lib/mysql_queries/src/queries/voice_designer/voice_samples/get_dataset_sample_by_uuid.rs
@@ -43,7 +43,7 @@ WHERE
         "#,
     uuid_idempotency_token,
   )
-      .fetch_one(mysql_connection)
+      .fetch_one(&mut **mysql_connection)
       .await;
 
   match maybe_result {

--- a/crates/lib/mysql_queries/src/queries/voice_designer/voice_samples/insert_dataset_sample_and_media_file.rs
+++ b/crates/lib/mysql_queries/src/queries/voice_designer/voice_samples/insert_dataset_sample_and_media_file.rs
@@ -53,7 +53,7 @@ const ORIGIN_PRODUCT : MediaFileOriginProductCategory = MediaFileOriginProductCa
 
 pub async fn insert_dataset_sample_and_media_file(args: InsertDatasetSampleAndMediaFileArgs<'_>) -> AnyhowResult<(ZsVoiceDatasetSampleToken, MediaFileToken, u64)> {
 
-  let mut maybe_creator_synthetic_id : Option<u64> = None;
+  let maybe_creator_synthetic_id : Option<u64> = None;
 
   let mut transaction = args.mysql_pool.begin().await?;
 
@@ -180,7 +180,7 @@ SET
         args.creator_set_visibility.to_str()
     );
 
-  let query_result = query.execute(&mut transaction)
+  let query_result = query.execute(&mut *transaction)
       .await;
 
   if let Err(err) = query_result {
@@ -214,7 +214,7 @@ SET
         args.creator_ip_address,
     );
 
-  let query_result = query.execute(&mut transaction)
+  let query_result = query.execute(&mut *transaction)
       .await;
 
   let result_tuple  = match query_result {

--- a/crates/lib/mysql_queries/src/queries/voice_designer/voice_samples/list_dataset_samples_for_dataset_token.rs
+++ b/crates/lib/mysql_queries/src/queries/voice_designer/voice_samples/list_dataset_samples_for_dataset_token.rs
@@ -119,7 +119,7 @@ async fn list_samples_by_dataset_token(
                     AND zds.mod_deleted_at IS NULL
             "#,
             dataset_token
-        ).fetch_all(mysql_connection).await?
+        ).fetch_all(&mut **mysql_connection).await?
     } else {
         sqlx::query_as!(
             InternalRawDatasetSampleRecordForList,
@@ -140,7 +140,7 @@ async fn list_samples_by_dataset_token(
                 WHERE zds.dataset_token = ?
             "#,
             dataset_token
-        ).fetch_all(mysql_connection).await?
+        ).fetch_all(&mut **mysql_connection).await?
     };
 
     Ok(maybe_samples)

--- a/crates/lib/mysql_queries/src/queries/voice_designer/voices/get_voice.rs
+++ b/crates/lib/mysql_queries/src/queries/voice_designer/voices/get_voice.rs
@@ -108,7 +108,7 @@ async fn select_include_deleted(
             "#,
         voice_token.as_str()
   )
-        .fetch_one(mysql_connection).await
+        .fetch_one(&mut **mysql_connection).await
 }
 
 async fn select_without_deleted(
@@ -137,7 +137,7 @@ async fn select_without_deleted(
             "#,
         voice_token.as_str()
   )
-        .fetch_one(mysql_connection).await
+        .fetch_one(&mut **mysql_connection).await
 }
 #[derive(Serialize)]
 pub struct RawVoice {

--- a/crates/lib/mysql_queries/src/queries/voice_designer/voices/list_voices_by_username.rs
+++ b/crates/lib/mysql_queries/src/queries/voice_designer/voices/list_voices_by_username.rs
@@ -118,7 +118,7 @@ async fn list_voices_by_creator_username(
             AND zv.mod_deleted_at IS NULL
         "#,
       creator_username)
-            .fetch_all(mysql_connection)
+            .fetch_all(&mut **mysql_connection)
             .await?
     } else {
         info!("listing voices for user");
@@ -145,7 +145,7 @@ async fn list_voices_by_creator_username(
             users.username = ?
         "#,
       creator_username)
-            .fetch_all(mysql_connection)
+            .fetch_all(&mut **mysql_connection)
             .await?
     };
 

--- a/crates/lib/mysql_queries/src/queries/voice_designer/voices/update_voice.rs
+++ b/crates/lib/mysql_queries/src/queries/voice_designer/voices/update_voice.rs
@@ -16,7 +16,7 @@ pub struct UpdateVoiceArgs<'a> {
 }
 
 pub async fn update_voice(args: UpdateVoiceArgs<'_>) -> AnyhowResult<()>{
-    let mut transaction = args.mysql_pool.begin().await?;
+    let transaction = args.mysql_pool.begin().await?;
 
     let query_result = sqlx::query!(
         r#"

--- a/crates/lib/mysql_queries/src/queries/w2l/stats/calculate_w2l_template_leaderboard.rs
+++ b/crates/lib/mysql_queries/src/queries/w2l/stats/calculate_w2l_template_leaderboard.rs
@@ -53,7 +53,7 @@ ORDER BY uploaded_count desc
 LIMIT 25;
         "#,
     )
-      .fetch_all(mysql_pool)
+      .fetch_all(&mut **mysql_pool)
       .await;
 
   let results : Vec<W2lLeaderboardRecordForListRaw> = match maybe_results {

--- a/crates/lib/mysql_queries/src/queries/w2l/w2l_download_jobs/w2l_download_job_queries.rs
+++ b/crates/lib/mysql_queries/src/queries/w2l/w2l_download_jobs/w2l_download_job_queries.rs
@@ -87,7 +87,7 @@ FOR UPDATE
         "#,
         job.id,
     )
-      .fetch_one(&mut transaction)
+      .fetch_one(&mut *transaction)
       .await;
 
   let record : W2lDownloadLockRecord = match maybe_record {
@@ -130,7 +130,7 @@ WHERE id = ?
         "#,
         job.id,
     )
-      .execute(&mut transaction)
+      .execute(&mut *transaction)
       .await?;
 
   transaction.commit().await?;
@@ -153,7 +153,7 @@ pub async fn mark_w2l_template_upload_job_failure(
     next_status = "dead";
   }
 
-  let query_result = sqlx::query!(
+  let _query_result = sqlx::query!(
         r#"
 UPDATE w2l_template_upload_jobs
 SET
@@ -177,7 +177,7 @@ pub async fn mark_w2l_template_upload_job_permanently_dead(
   job: &W2lTemplateUploadJobRecord,
   failure_reason: &str,
 ) -> AnyhowResult<()> {
-  let query_result = sqlx::query!(
+  let _query_result = sqlx::query!(
         r#"
 UPDATE w2l_template_upload_jobs
 SET
@@ -204,7 +204,7 @@ pub async fn mark_w2l_template_upload_job_done(
 {
   let status = if success { "complete_success" } else { "complete_failure" };
 
-  let query_result = sqlx::query!(
+  let _query_result = sqlx::query!(
         r#"
 UPDATE w2l_template_upload_jobs
 SET

--- a/crates/lib/mysql_queries/src/queries/w2l/w2l_inference_jobs/insert_w2l_inference_job.rs
+++ b/crates/lib/mysql_queries/src/queries/w2l/w2l_inference_jobs/insert_w2l_inference_job.rs
@@ -41,7 +41,7 @@ SET
       .execute(args.mysql_pool)
       .await;
 
-  let record_id = match query_result {
+  let _record_id = match query_result {
     Ok(res) => {
       res.last_insert_id()
     },

--- a/crates/lib/mysql_queries/src/queries/w2l/w2l_inference_jobs/w2l_inference_job_queries.rs
+++ b/crates/lib/mysql_queries/src/queries/w2l/w2l_inference_jobs/w2l_inference_job_queries.rs
@@ -134,7 +134,7 @@ FOR UPDATE
         "#,
         job.id,
     )
-      .fetch_one(&mut transaction)
+      .fetch_one(&mut *transaction)
       .await;
 
   let record : W2lInferenceLockRecord = match maybe_record {
@@ -177,7 +177,7 @@ WHERE id = ?
         "#,
         job.id,
     )
-      .execute(&mut transaction)
+      .execute(&mut *transaction)
       .await?;
 
   transaction.commit().await?;
@@ -201,7 +201,7 @@ pub async fn mark_w2l_inference_job_failure(
     next_status = "dead";
   }
 
-  let query_result = sqlx::query!(
+  let _query_result = sqlx::query!(
         r#"
 UPDATE w2l_inference_jobs
 SET
@@ -228,7 +228,7 @@ pub async fn mark_w2l_inference_job_done(
 ) -> AnyhowResult<()> {
   let status = if success { "complete_success" } else { "complete_failure" };
 
-  let query_result = sqlx::query!(
+  let _query_result = sqlx::query!(
         r#"
 UPDATE w2l_inference_jobs
 SET
@@ -289,7 +289,7 @@ ON DUPLICATE KEY UPDATE
       creator_user_token,
       creator_user_token
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await;
 
     match query_result {
@@ -313,7 +313,7 @@ LIMIT 1
         "#,
       creator_user_token,
     )
-        .fetch_one(&mut transaction)
+        .fetch_one(&mut *transaction)
         .await;
 
     let record : SyntheticIdRecord = match query_result {
@@ -366,7 +366,7 @@ SET
       frame_height,
       duration_millis
     )
-        .execute(&mut transaction)
+        .execute(&mut *transaction)
         .await;
 
     let record_id = match query_result {

--- a/crates/lib/sqlite_queries/Cargo.toml
+++ b/crates/lib/sqlite_queries/Cargo.toml
@@ -20,7 +20,7 @@ errors = { path = "../../lib/errors" }
 tokens = { path = "../../_types/tokens" }
 
 # External
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 dotenv = "0.15.0"
 log = "0.4.14"
 
@@ -33,7 +33,7 @@ regex = "1.5.4"
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
 #  ^^^ Granted, this applies to *MySQL* and probably not SQLite for our use case here ^^^
-sqlx = { version = "0.6.2", features = [ "sqlite", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "sqlite", "runtime-tokio-native-tls", "chrono" ] }
 
 [dev-dependencies]
 # None yet

--- a/crates/lib/sqlx_mysql_helpers/Cargo.toml
+++ b/crates/lib/sqlx_mysql_helpers/Cargo.toml
@@ -20,7 +20,8 @@ errors = { path = "../errors" }
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
+
 my-workspace-hack = { version = "0.1", path = "../../../my-workspace-hack" }
 
 [dev-dependencies]

--- a/crates/lib/tts_common/Cargo.toml
+++ b/crates/lib/tts_common/Cargo.toml
@@ -20,7 +20,7 @@ user_input_common = { path = "../user_input_common" }
 
 # External
 anyhow = "1.0.75"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 log = "0.4.14"
 once_cell = "1.18.0"
 regex = "1.5.4"

--- a/crates/lib/web_scrapers/Cargo.toml
+++ b/crates/lib/web_scrapers/Cargo.toml
@@ -19,7 +19,7 @@ errors = { path = "../../lib/errors" }
 
 # External
 bytes = "1.3"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 log = "0.4.14"
 once_cell = "1.18.0"
 strum = { version = "0.25", features = ["derive"] } # Fancy enum iteration, etc.

--- a/crates/programs/aichatbot-sidecar/Cargo.toml
+++ b/crates/programs/aichatbot-sidecar/Cargo.toml
@@ -32,7 +32,7 @@ web_scrapers = { path = "../../lib/web_scrapers" }
 
 # External
 base64 = "0.21.0"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 clap = "2.34.0" # TODO: This is really out of date, but has conflicts when updated
 dotenv = "0.15.0"
 log = "0.4.14"
@@ -47,7 +47,7 @@ strum = { version = "0.24", features = ["derive"] } # Fancy enum iteration, etc.
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
 #  ^^^ Granted, this applies to *MySQL* and probably not SQLite for our use case here ^^^
-sqlx = { version = "0.6.2", features = [ "sqlite", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "sqlite", "runtime-tokio-native-tls", "chrono" ] }
 
 # Async Runtime
 tokio = { version = "1.6.0", features = ["macros"] }

--- a/crates/service/job/analytics_job/Cargo.toml
+++ b/crates/service/job/analytics_job/Cargo.toml
@@ -26,7 +26,7 @@ tokens = { path = "../../../_types/tokens" }
 
 # External
 anyhow = "1.0.75"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 dotenv = "0.15.0"
 hostname = "0.3.1"
 log = "0.4.14"
@@ -36,7 +36,7 @@ rand = "0.8.3"
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 
 # Runtime
 # NB: We switched to Tokio from `async-std` for broader ecosystem support.

--- a/crates/service/job/download_job/Cargo.toml
+++ b/crates/service/job/download_job/Cargo.toml
@@ -35,7 +35,7 @@ subprocess_common = { path = "../../../lib/subprocess_common" }
 
 # External
 anyhow = "1.0.75"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 dotenv = "0.15.0"
 hostname = "0.3.1"
 log = "0.4.14"
@@ -47,7 +47,7 @@ zip = "0.6.6"
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 
 # Redis
 r2d2_redis = "0.14.0"

--- a/crates/service/job/email_sender_job/Cargo.toml
+++ b/crates/service/job/email_sender_job/Cargo.toml
@@ -46,7 +46,7 @@ tts_common = { path = "../../../lib/tts_common" }
 
 # External
 anyhow = "1.0.75"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 clap = "2.34.0" # TODO: This is really out of date, but has conflicts when updated
 dotenv = "0.15.0"
 hostname = "0.3.1"
@@ -60,7 +60,7 @@ tempdir = "0.3.7"
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 
 # Redis
 r2d2_redis = "0.14.0"

--- a/crates/service/job/inference_job/Cargo.toml
+++ b/crates/service/job/inference_job/Cargo.toml
@@ -43,7 +43,7 @@ newrelic-telemetry = { path = "../../../vendor/newrelic-telemetry-sdk-rust" }
 
 # External
 anyhow = "1.0.75"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 dotenv = "0.15.0"
 hostname = "0.3.1"
 log = "0.4.14"
@@ -55,7 +55,7 @@ tempdir = "0.3.7"
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 
 # Redis
 r2d2_redis = "0.14.0"

--- a/crates/service/job/tts_download_job/Cargo.toml
+++ b/crates/service/job/tts_download_job/Cargo.toml
@@ -27,7 +27,7 @@ mysql_queries = { path = "../../../lib/mysql_queries" }
 
 # External
 anyhow = "1.0.75"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 dotenv = "0.15.0"
 hostname = "0.3.1"
 log = "0.4.14"
@@ -38,7 +38,7 @@ tempdir = "0.3.7"
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 
 # Redis
 r2d2_redis = "0.14.0"

--- a/crates/service/job/tts_inference_job/Cargo.toml
+++ b/crates/service/job/tts_inference_job/Cargo.toml
@@ -30,7 +30,7 @@ newrelic-telemetry = { path = "../../../vendor/newrelic-telemetry-sdk-rust" }
 
 # External
 anyhow = "1.0.75"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 clap = "2.34.0" # TODO: This is really out of date, but has conflicts when updated
 dotenv = "0.15.0"
 hostname = "0.3.1"
@@ -43,7 +43,7 @@ tempdir = "0.3.7"
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 
 # Redis
 r2d2_redis = "0.14.0"

--- a/crates/service/job/w2l_download_job/Cargo.toml
+++ b/crates/service/job/w2l_download_job/Cargo.toml
@@ -27,7 +27,7 @@ mysql_queries = { path = "../../../lib/mysql_queries" }
 
 # External
 anyhow = "1.0.75"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 dotenv = "0.15.0"
 hostname = "0.3.1"
 log = "0.4.14"
@@ -38,7 +38,7 @@ tempdir = "0.3.7"
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 
 # Redis
 r2d2_redis = "0.14.0"

--- a/crates/service/job/w2l_inference_job/Cargo.toml
+++ b/crates/service/job/w2l_inference_job/Cargo.toml
@@ -25,7 +25,7 @@ mysql_queries = { path = "../../../lib/mysql_queries" }
 
 # External
 anyhow = "1.0.75"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 dotenv = "0.15.0"
 hostname = "0.3.1"
 log = "0.4.14"
@@ -36,7 +36,7 @@ tempdir = "0.3.7"
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 
 # Redis
 r2d2_redis = "0.14.0"

--- a/crates/service/other/twitch_pubsub_subscriber/Cargo.toml
+++ b/crates/service/other/twitch_pubsub_subscriber/Cargo.toml
@@ -27,7 +27,7 @@ twitch_common = { path = "../../../lib/api_clients/twitch_common" }
 # External
 anyhow = "1.0.75"
 base64 = "0.21.0"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 dotenv = "0.15.0"
 hostname = "0.3.1"
 lazy_static = "1.4.0"
@@ -51,7 +51,7 @@ futures_old_for_limiter = { package = "futures", version = "0.1.29" } # Older ve
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 
 # Redis Database
 r2d2_redis = "0.14.0"

--- a/crates/service/plugins/billing/Cargo.toml
+++ b/crates/service/plugins/billing/Cargo.toml
@@ -24,7 +24,7 @@ url_config = { path = "../../../lib/url_config" }
 # External
 anyhow = "1.0.75"
 base64 = "0.21.0"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 dotenv = "0.15.0"
 log = "0.4.14"
 once_cell = "1.18.0"
@@ -54,7 +54,7 @@ async-trait = "0.1.58"
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 my-workspace-hack = { version = "0.1", path = "../../../../my-workspace-hack" }
 
 [dev-dependencies]

--- a/crates/service/plugins/users/Cargo.toml
+++ b/crates/service/plugins/users/Cargo.toml
@@ -34,7 +34,7 @@ user_input_common = { path = "../../../lib/user_input_common" }
 # External
 anyhow = "1.0.75"
 base64 = "0.21.0"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 dotenv = "0.15.0"
 lazy_static = "1.4.0" # Regex caching (TODO: Use OnceCell instead)
 log = "0.4.14"
@@ -62,7 +62,7 @@ toml = "0.5.8"
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 
 # TODO: Shouldn't really be a dependency, but need to add caching for the DDoS attack.
 # Redis Database

--- a/crates/service/plugins/users/src/utils/session_checker.rs
+++ b/crates/service/plugins/users/src/utils/session_checker.rs
@@ -67,7 +67,7 @@ impl SessionChecker {
     mysql_connection: &mut PoolConnection<MySql>,
   ) -> AnyhowResult<Option<SessionRecord>>
   {
-    self.do_session_light_lookup_and_cookie_decode(request, mysql_connection).await
+    self.do_session_light_lookup_and_cookie_decode(request, &mut **mysql_connection).await
   }
 
 
@@ -127,7 +127,7 @@ impl SessionChecker {
     mysql_connection: &mut PoolConnection<MySql>,
   ) -> AnyhowResult<Option<SessionUserRecord>>
   {
-    self.do_user_session_lookup_and_cookie_decode(request, mysql_connection).await
+    self.do_user_session_lookup_and_cookie_decode(request, &mut **mysql_connection).await
   }
 
 

--- a/crates/service/web/dummy_service/Cargo.toml
+++ b/crates/service/web/dummy_service/Cargo.toml
@@ -21,7 +21,7 @@ errors = { path = "../../../lib/errors" }
 reusable_types = { path = "../../../_types/reusable_types" }
 
 # External
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 dotenv = "0.15.0"
 hostname = "0.3.1"
 #once_cell = "1.9.0"

--- a/crates/service/web/storyteller_web/Cargo.toml
+++ b/crates/service/web/storyteller_web/Cargo.toml
@@ -54,7 +54,7 @@ users_component = { path = "../../plugins/users" }
 # External
 anyhow = "1.0.75"
 base64 = "0.21.0"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 derive_more = "0.99.17"
 dotenv = "0.15.0"
 hex = "0.4.3"
@@ -101,7 +101,7 @@ pin-project-lite = "0.2.9" # NB: For middleware/futures upgrade
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 
 # Redis Database
 limitation = "0.1.1" # Redis rate limiter

--- a/crates/service/web/storyteller_web/src/http_server/endpoints/comments/create_comment_handler.rs
+++ b/crates/service/web/storyteller_web/src/http_server/endpoints/comments/create_comment_handler.rs
@@ -120,7 +120,7 @@ pub async fn create_comment_handler(
     comment_markdown: &markdown,
     comment_rendered_html: &html,
     creator_ip_address: &ip_address,
-    mysql_executor: &mut mysql_connection,
+    mysql_executor: &mut *mysql_connection,
     phantom: Default::default(),
   }).await;
 

--- a/crates/service/web/storyteller_web/src/http_server/endpoints/comments/delete_comment_handler.rs
+++ b/crates/service/web/storyteller_web/src/http_server/endpoints/comments/delete_comment_handler.rs
@@ -105,7 +105,7 @@ pub async fn delete_comment_handler(
     // 1) Delete as moderator
     maybe_delete_as = Some(DeleteCommentAs::Moderator);
   } else {
-    let comment = get_comment(&path.comment_token, &mut mysql_connection)
+    let comment = get_comment(&path.comment_token, &mut *mysql_connection)
         .await
         .map_err(|err| {
           error!("error with query: {:?}", err);
@@ -137,7 +137,7 @@ pub async fn delete_comment_handler(
   let query_result = delete_comment(
     &path.comment_token,
     delete_as,
-    &mut mysql_connection
+    &mut *mysql_connection
   ).await;
 
   match query_result {

--- a/crates/service/web/websocket_gateway/Cargo.toml
+++ b/crates/service/web/websocket_gateway/Cargo.toml
@@ -27,7 +27,7 @@ twitch_common = { path = "../../../lib/api_clients/twitch_common" }
 # External
 anyhow = "1.0.75"
 base64 = "0.21.0"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.22", features = ["serde"] }
 derive_more = "0.99.17"
 dotenv = "0.15.0"
 hostname = "0.3.1"
@@ -51,7 +51,7 @@ futures_old_for_limiter = { package = "futures", version = "0.1.29" } # Older ve
 # "offline" supports typesafe builds without a live database
 # "rustls" doesn't appear to work with IP addresses, per:
 # https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828
-sqlx = { version = "0.6.2", features = [ "mysql", "runtime-actix-native-tls", "offline", "chrono" ] }
+sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-native-tls", "chrono" ] }
 
 # Redis Database
 limitation = "0.1.1" # Redis rate limiter

--- a/my-workspace-hack/Cargo.toml
+++ b/my-workspace-hack/Cargo.toml
@@ -14,170 +14,152 @@ publish = false
 
 ### BEGIN HAKARI SECTION
 [dependencies]
-actix-rt = { version = "2" }
-ahash = { version = "0.7" }
-base64ct = { version = "1", default-features = false, features = ["alloc"] }
-bitflags = { version = "1" }
-block-buffer = { version = "0.9", default-features = false, features = ["block-padding"] }
-bytemuck = { version = "1", default-features = false, features = ["extern_crate_alloc"] }
-byteorder = { version = "1" }
-chrono = { version = "0.4", features = ["alloc", "serde"] }
-combine = { version = "4", default-features = false, features = ["std", "tokio"] }
-crossbeam-utils = { version = "0.8" }
-digest = { version = "0.10", features = ["mac", "std"] }
-either = { version = "1", features = ["serde"] }
-flate2 = { version = "1" }
-flume = { version = "0.10" }
-futures = { version = "0.3", features = ["thread-pool"] }
-futures-channel = { version = "0.3", features = ["sink"] }
-futures-core = { version = "0.3" }
-futures-executor = { version = "0.3", features = ["thread-pool"] }
-futures-io = { version = "0.3" }
-futures-sink = { version = "0.3" }
-futures-task = { version = "0.3", default-features = false, features = ["std"] }
-futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
-generic-array = { version = "0.14", default-features = false, features = ["more_lengths"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "rdrand", "std"] }
-getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
-hashbrown = { version = "0.12", features = ["raw"] }
-hmac = { version = "0.12", default-features = false, features = ["reset"] }
-hyper = { version = "0.14", features = ["client", "http1", "http2", "server", "tcp"] }
-indexmap = { version = "1", default-features = false, features = ["std"] }
-lazy_static = { version = "1", default-features = false, features = ["spin_no_std"] }
-log = { version = "0.4", default-features = false, features = ["std"] }
-memchr = { version = "2", features = ["use_std"] }
-miniz_oxide = { version = "0.7", features = ["simd"] }
-native-tls = { version = "0.2", default-features = false, features = ["vendored"] }
-num-bigint = { version = "0.4" }
-num-integer = { version = "0.1", features = ["i128"] }
-num-iter = { version = "0.1" }
-num-traits = { version = "0.2", features = ["i128", "libm"] }
-parking_lot = { version = "0.12", features = ["send_guard"] }
-rand = { version = "0.8", features = ["small_rng"] }
-rand_core = { version = "0.6", default-features = false, features = ["std"] }
-regex = { version = "1" }
-regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
-regex-syntax = { version = "0.8" }
-reqwest = { version = "0.11", features = ["gzip", "json", "native-tls", "stream"] }
-serde = { version = "1", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1", features = ["raw_value"] }
-sha1 = { version = "0.10" }
-sha2 = { version = "0.10" }
-simd-adler32 = { version = "0.3" }
-socket2 = { version = "0.4", default-features = false, features = ["all"] }
-sqlx = { version = "0.6", features = ["chrono", "mysql", "offline", "runtime-actix-native-tls", "sqlite"] }
-sqlx-core = { version = "0.6", features = ["any", "chrono", "mysql", "offline", "runtime-tokio-native-tls", "sqlite"] }
-standback = { version = "0.2", default-features = false, features = ["std"] }
-time = { version = "0.3", features = ["macros", "serde-well-known"] }
-tokio-6f8ce4dd05d13bba = { package = "tokio", version = "0.2", features = ["blocking", "io-util", "rt-util", "signal", "stream", "sync", "tcp", "time", "udp", "uds"] }
-tokio-dff4ba8e3ae991db = { package = "tokio", version = "1", features = ["fs", "io-util", "macros", "net", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
-tokio-stream = { version = "0.1", features = ["fs"] }
-tokio-util-3b31131e45eafb45 = { package = "tokio-util", version = "0.6", features = ["codec", "io"] }
-tokio-util-ca01ad9e24f5d932 = { package = "tokio-util", version = "0.7", features = ["codec", "io"] }
-tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
-tracing-core = { version = "0.1", default-features = false, features = ["std"] }
-twitch_oauth2 = { version = "0.6", features = ["reqwest_client"] }
-unicode-bidi = { version = "0.3" }
-unicode-normalization = { version = "0.1" }
-url = { version = "2", features = ["serde"] }
-void = { version = "1" }
+actix-rt = { version = "2.9.0" }
+ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8.3" }
+ahash-ca01ad9e24f5d932 = { package = "ahash", version = "0.7.6" }
+base64 = { version = "0.21.0" }
+base64ct = { version = "1.5.3", default-features = false, features = ["alloc"] }
+bitflags = { version = "2.4.0", default-features = false, features = ["serde"] }
+block-buffer = { version = "0.9.0", default-features = false, features = ["block-padding"] }
+bytemuck = { version = "1.12.3", default-features = false, features = ["extern_crate_alloc"] }
+byteorder = { version = "1.5.0" }
+chrono = { version = "0.4.22", features = ["alloc", "serde"] }
+combine = { version = "4.6.3", default-features = false, features = ["std", "tokio"] }
+crossbeam-utils = { version = "0.8.16" }
+digest = { version = "0.10.7", features = ["mac", "oid", "std"] }
+either = { version = "1.6.1", features = ["serde"] }
+flate2 = { version = "1.0.26" }
+futures = { version = "0.3.26", features = ["thread-pool"] }
+futures-channel = { version = "0.3.29", features = ["sink"] }
+futures-core = { version = "0.3.29" }
+futures-executor = { version = "0.3.26", features = ["thread-pool"] }
+futures-io = { version = "0.3.29" }
+futures-sink = { version = "0.3.29" }
+futures-util = { version = "0.3.29", features = ["channel", "io", "sink"] }
+generic-array = { version = "0.14.4", default-features = false, features = ["more_lengths"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.8", default-features = false, features = ["js", "rdrand", "std"] }
+getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1.16", default-features = false, features = ["std"] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14.2", features = ["raw"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12.3", features = ["raw"] }
+hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
+hyper = { version = "0.14.24", features = ["client", "http1", "http2", "runtime", "server"] }
+lazy_static = { version = "1.4.0", default-features = false, features = ["spin_no_std"] }
+libc = { version = "0.2.150", features = ["align", "extra_traits"] }
+log = { version = "0.4.20", default-features = false, features = ["std"] }
+memchr = { version = "2.6.4", features = ["use_std"] }
+miniz_oxide = { version = "0.7.1", features = ["simd"] }
+mio = { version = "0.8.9", features = ["net", "os-ext"] }
+native-tls = { version = "0.2.10", default-features = false, features = ["vendored"] }
+num-integer = { version = "0.1.44", features = ["i128"] }
+num-iter = { version = "0.1.42" }
+num-traits = { version = "0.2.15", features = ["i128", "libm"] }
+once_cell = { version = "1.18.0", features = ["unstable"] }
+parking_lot = { version = "0.12.1", features = ["send_guard"] }
+rand = { version = "0.8.5", features = ["small_rng"] }
+rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
+regex = { version = "1.10.0" }
+regex-automata = { version = "0.4.1", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-syntax = { version = "0.8.0" }
+reqwest = { version = "0.11.14", features = ["gzip", "json", "native-tls", "stream"] }
+serde = { version = "1.0.179", features = ["alloc", "derive", "rc"] }
+serde_json = { version = "1.0.108", features = ["raw_value"] }
+sha1 = { version = "0.10.4" }
+sha2 = { version = "0.10.5" }
+simd-adler32 = { version = "0.3.7" }
+socket2-9fbad63c4bcf4a8f = { package = "socket2", version = "0.4.7", default-features = false, features = ["all"] }
+socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5.5", default-features = false, features = ["all"] }
+sqlx = { version = "0.7.2", features = ["chrono", "mysql", "runtime-tokio-native-tls", "sqlite"] }
+sqlx-mysql = { version = "0.7.2", default-features = false, features = ["any", "chrono", "json", "migrate", "offline"] }
+sqlx-sqlite = { version = "0.7.2", default-features = false, features = ["any", "chrono", "json", "migrate", "offline"] }
+time = { version = "0.3.14", features = ["macros", "serde-well-known"] }
+tokio = { version = "1.34.0", features = ["fs", "io-util", "macros", "net", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-stream = { version = "0.1.11", features = ["fs"] }
+tokio-util-3b31131e45eafb45 = { package = "tokio-util", version = "0.6.9", features = ["codec", "io"] }
+tokio-util-ca01ad9e24f5d932 = { package = "tokio-util", version = "0.7.4", features = ["codec", "io"] }
+tracing = { version = "0.1.37", features = ["log"] }
+twitch_oauth2 = { version = "0.6.0", features = ["reqwest_client"] }
+unicode-bidi = { version = "0.3.13" }
+unicode-normalization = { version = "0.1.22" }
+url = { version = "2.4.1", features = ["serde"] }
+void = { version = "1.0.2" }
 
 [build-dependencies]
-ahash = { version = "0.7" }
-base64ct = { version = "1", default-features = false, features = ["alloc"] }
-bitflags = { version = "1" }
-byteorder = { version = "1" }
-cc = { version = "1", default-features = false, features = ["parallel"] }
-chrono = { version = "0.4", features = ["alloc", "serde"] }
-crossbeam-utils = { version = "0.8" }
-derive_more = { version = "0.99" }
-digest = { version = "0.10", features = ["mac", "std"] }
-either = { version = "1", features = ["serde"] }
-flume = { version = "0.10" }
-futures-channel = { version = "0.3", features = ["sink"] }
-futures-core = { version = "0.3" }
-futures-executor = { version = "0.3", features = ["thread-pool"] }
-futures-io = { version = "0.3" }
-futures-sink = { version = "0.3" }
-futures-task = { version = "0.3", default-features = false, features = ["std"] }
-futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
-generic-array = { version = "0.14", default-features = false, features = ["more_lengths"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "rdrand", "std"] }
-hashbrown = { version = "0.12", features = ["raw"] }
-indexmap = { version = "1", default-features = false, features = ["std"] }
-lazy_static = { version = "1", default-features = false, features = ["spin_no_std"] }
-log = { version = "0.4", default-features = false, features = ["std"] }
-memchr = { version = "2", features = ["use_std"] }
-native-tls = { version = "0.2", default-features = false, features = ["vendored"] }
-num-bigint = { version = "0.4" }
-num-integer = { version = "0.1", features = ["i128"] }
-num-iter = { version = "0.1" }
-num-traits = { version = "0.2", features = ["i128", "libm"] }
-parking_lot = { version = "0.12", features = ["send_guard"] }
-rand = { version = "0.8", features = ["small_rng"] }
-rand_core = { version = "0.6", default-features = false, features = ["std"] }
-regex = { version = "1" }
-regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
-regex-syntax = { version = "0.8" }
-serde = { version = "1", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1", features = ["raw_value"] }
-sha1 = { version = "0.10" }
-sha2 = { version = "0.10" }
-sqlx-core = { version = "0.6", features = ["any", "chrono", "mysql", "offline", "runtime-tokio-native-tls", "sqlite"] }
-sqlx-macros = { version = "0.6", default-features = false, features = ["chrono", "migrate", "mysql", "offline", "runtime-tokio-native-tls", "sqlite"] }
-standback = { version = "0.2", default-features = false, features = ["std"] }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit-mut"] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "fold", "full"] }
-tokio-dff4ba8e3ae991db = { package = "tokio", version = "1", features = ["fs", "io-util", "macros", "net", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
-tokio-stream = { version = "0.1", features = ["fs"] }
-tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
-tracing-core = { version = "0.1", default-features = false, features = ["std"] }
-unicode-bidi = { version = "0.3" }
-unicode-normalization = { version = "0.1" }
-url = { version = "2", features = ["serde"] }
-
-[target.x86_64-unknown-linux-musl.dependencies]
-hyper = { version = "0.14", default-features = false, features = ["runtime"] }
-libc = { version = "0.2", features = ["align", "extra_traits"] }
-once_cell = { version = "1", features = ["unstable"] }
-openssl = { version = "0.10", features = ["vendored"] }
-openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
-
-[target.x86_64-unknown-linux-musl.build-dependencies]
-libc = { version = "0.2", features = ["align", "extra_traits"] }
-once_cell = { version = "1", features = ["unstable"] }
-openssl = { version = "0.10", features = ["vendored"] }
-openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
-
-[target.aarch64-apple-darwin.dependencies]
-hyper = { version = "0.14", default-features = false, features = ["runtime"] }
-libc = { version = "0.2", features = ["align", "extra_traits"] }
-once_cell = { version = "1", features = ["unstable"] }
-
-[target.aarch64-apple-darwin.build-dependencies]
-libc = { version = "0.2", features = ["align", "extra_traits"] }
-once_cell = { version = "1", features = ["unstable"] }
+ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8.3" }
+ahash-ca01ad9e24f5d932 = { package = "ahash", version = "0.7.6" }
+base64 = { version = "0.21.0" }
+base64ct = { version = "1.5.3", default-features = false, features = ["alloc"] }
+bitflags = { version = "2.4.0", default-features = false, features = ["serde"] }
+byteorder = { version = "1.5.0" }
+cc = { version = "1.0.79", default-features = false, features = ["parallel"] }
+chrono = { version = "0.4.22", features = ["alloc", "serde"] }
+crossbeam-utils = { version = "0.8.16" }
+derive_more = { version = "0.99.17" }
+digest = { version = "0.10.7", features = ["mac", "oid", "std"] }
+either = { version = "1.6.1", features = ["serde"] }
+futures-channel = { version = "0.3.29", features = ["sink"] }
+futures-core = { version = "0.3.29" }
+futures-executor = { version = "0.3.26", features = ["thread-pool"] }
+futures-io = { version = "0.3.29" }
+futures-sink = { version = "0.3.29" }
+futures-util = { version = "0.3.29", features = ["channel", "io", "sink"] }
+generic-array = { version = "0.14.4", default-features = false, features = ["more_lengths"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.8", default-features = false, features = ["js", "rdrand", "std"] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14.2", features = ["raw"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12.3", features = ["raw"] }
+heck = { version = "0.4.1", features = ["unicode"] }
+hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
+lazy_static = { version = "1.4.0", default-features = false, features = ["spin_no_std"] }
+libc = { version = "0.2.150", features = ["align", "extra_traits"] }
+log = { version = "0.4.20", default-features = false, features = ["std"] }
+memchr = { version = "2.6.4", features = ["use_std"] }
+mio = { version = "0.8.9", features = ["net", "os-ext"] }
+native-tls = { version = "0.2.10", default-features = false, features = ["vendored"] }
+num-integer = { version = "0.1.44", features = ["i128"] }
+num-iter = { version = "0.1.42" }
+num-traits = { version = "0.2.15", features = ["i128", "libm"] }
+once_cell = { version = "1.18.0", features = ["unstable"] }
+parking_lot = { version = "0.12.1", features = ["send_guard"] }
+rand = { version = "0.8.5", features = ["small_rng"] }
+rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
+regex = { version = "1.10.0" }
+regex-automata = { version = "0.4.1", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-syntax = { version = "0.8.0" }
+serde = { version = "1.0.179", features = ["alloc", "derive", "rc"] }
+serde_json = { version = "1.0.108", features = ["raw_value"] }
+sha1 = { version = "0.10.4" }
+sha2 = { version = "0.10.5" }
+sqlx-macros = { version = "0.7.2", features = ["_rt-tokio", "_tls-native-tls", "chrono", "json", "migrate", "mysql", "sqlite"] }
+sqlx-macros-core = { version = "0.7.2", features = ["_rt-tokio", "_tls-native-tls", "chrono", "json", "migrate", "mysql", "sqlite"] }
+sqlx-mysql = { version = "0.7.2", default-features = false, features = ["any", "chrono", "json", "migrate", "offline"] }
+sqlx-sqlite = { version = "0.7.2", default-features = false, features = ["any", "chrono", "json", "migrate", "offline"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.26", features = ["extra-traits", "fold", "full", "visit-mut"] }
+tokio = { version = "1.34.0", features = ["fs", "io-util", "macros", "net", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-stream = { version = "0.1.11", features = ["fs"] }
+tracing = { version = "0.1.37", features = ["log"] }
+unicode-bidi = { version = "0.3.13" }
+unicode-normalization = { version = "0.1.22" }
+url = { version = "2.4.1", features = ["serde"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-hyper = { version = "0.14", default-features = false, features = ["runtime"] }
-libc = { version = "0.2", features = ["align", "extra_traits"] }
-once_cell = { version = "1", features = ["unstable"] }
-openssl = { version = "0.10", features = ["vendored"] }
-openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
+openssl = { version = "0.10.57", features = ["vendored"] }
+openssl-sys = { version = "0.9.93", default-features = false, features = ["vendored"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
-libc = { version = "0.2", features = ["align", "extra_traits"] }
-once_cell = { version = "1", features = ["unstable"] }
-openssl = { version = "0.10", features = ["vendored"] }
-openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
-
-[target.x86_64-apple-darwin.dependencies]
-hyper = { version = "0.14", default-features = false, features = ["runtime"] }
-libc = { version = "0.2", features = ["align", "extra_traits"] }
-once_cell = { version = "1", features = ["unstable"] }
+openssl = { version = "0.10.57", features = ["vendored"] }
+openssl-sys = { version = "0.9.93", default-features = false, features = ["vendored"] }
+socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5.5", default-features = false, features = ["all"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-libc = { version = "0.2", features = ["align", "extra_traits"] }
-once_cell = { version = "1", features = ["unstable"] }
+socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5.5", default-features = false, features = ["all"] }
+
+[target.x86_64-pc-windows-msvc.dependencies]
+winapi = { version = "0.3.9", default-features = false, features = ["consoleapi", "errhandlingapi", "fibersapi", "fileapi", "handleapi", "impl-debug", "impl-default", "knownfolders", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "schannel", "securitybaseapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winreg", "winsock2", "ws2def", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+windows-sys = { version = "0.48.0", features = ["Win32_Foundation", "Win32_NetworkManagement_IpHelper", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
+
+[target.x86_64-pc-windows-msvc.build-dependencies]
+socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5.5", default-features = false, features = ["all"] }
+winapi = { version = "0.3.9", default-features = false, features = ["consoleapi", "errhandlingapi", "fibersapi", "fileapi", "handleapi", "impl-debug", "impl-default", "knownfolders", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "schannel", "securitybaseapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winreg", "winsock2", "ws2def", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+windows-sys = { version = "0.48.0", features = ["Win32_Foundation", "Win32_NetworkManagement_IpHelper", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
Hypothetically this unblocks native rustls over IP address. If so, we can drop native OpenSSL and Ubuntu packages and make a much simpler build.

See this issue:
https://github.com/launchbadge/sqlx/issues/1095#issuecomment-798050828

Had to deal with a few migration issues,

- changes to transactor types: https://github.com/launchbadge/sqlx/issues/2606

- changes to sqlx_core that impacted our serialization/deserialization macros