### PR TITLE
vendor `limitation` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "smallvec 1.11.2",
- "tokio",
+ "tokio 1.34.0",
  "tokio-util",
 ]
 
@@ -39,7 +39,7 @@ dependencies = [
  "futures-sink",
  "memchr",
  "pin-project-lite",
- "tokio",
+ "tokio 1.34.0",
  "tokio-util",
  "tracing",
 ]
@@ -78,7 +78,7 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
 ]
 
@@ -110,12 +110,12 @@ dependencies = [
  "language-tags",
  "local-channel",
  "mime",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "rand 0.8.5",
  "sha1 0.10.6",
  "smallvec 1.11.2",
- "tokio",
+ "tokio 1.34.0",
  "tokio-util",
  "tracing",
  "zstd 0.12.4",
@@ -127,7 +127,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
- "quote",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -153,7 +153,7 @@ dependencies = [
  "serde_json",
  "serde_plain",
  "tempfile",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -164,8 +164,8 @@ checksum = "0a0a77f836d869f700e5b47ac7c3c8b9c8bc82e4aec861954c6198abee3ebd4d"
 dependencies = [
  "darling 0.20.3",
  "parse-size",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -190,7 +190,7 @@ checksum = "28f32d40287d3f402ae0028a9d54bef51af15c8769492826a69d28f81893151d"
 dependencies = [
  "actix-macros",
  "futures-core",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -206,7 +206,7 @@ dependencies = [
  "futures-util",
  "mio 0.8.9",
  "socket2 0.5.5",
- "tokio",
+ "tokio 1.34.0",
  "tracing",
 ]
 
@@ -268,7 +268,7 @@ dependencies = [
  "smallvec 1.11.2",
  "socket2 0.5.5",
  "time 0.3.30",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -285,7 +285,7 @@ dependencies = [
  "bytestring",
  "futures-core",
  "pin-project-lite",
- "tokio",
+ "tokio 1.34.0",
  "tokio-util",
 ]
 
@@ -296,8 +296,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1f50ebbb30eca122b188319a4398b3f7bb4a8cdf50ecfb73bfc6a3c3ce54f5"
 dependencies = [
  "actix-router",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -307,8 +307,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -416,8 +416,8 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f9afe97decc070be1864d96ab118383abed1c58fc09696663666049431110c5"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -465,7 +465,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokens",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -594,7 +594,7 @@ dependencies = [
  "futures-core",
  "memchr",
  "pin-project-lite",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -618,7 +618,7 @@ dependencies = [
  "smart-default",
  "smol_str",
  "thiserror",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -627,8 +627,8 @@ version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -675,7 +675,7 @@ dependencies = [
  "native-tls",
  "serde",
  "serde_json",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -709,7 +709,7 @@ dependencies = [
  "serde",
  "thiserror",
  "time 0.3.30",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -804,7 +804,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sqlx",
- "tokio",
+ "tokio 1.34.0",
  "toml",
  "url_config",
 ]
@@ -1137,8 +1137,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -1157,7 +1157,7 @@ dependencies = [
  "log",
  "my-workspace-hack",
  "rust-s3",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -1213,7 +1213,7 @@ dependencies = [
  "futures-core",
  "memchr",
  "pin-project-lite",
- "tokio",
+ "tokio 1.34.0",
  "tokio-util",
 ]
 
@@ -1247,7 +1247,7 @@ dependencies = [
  "anyhow",
  "easyenv",
  "my-workspace-hack",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -1289,7 +1289,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "time 0.3.30",
  "version_check",
 ]
@@ -1383,13 +1383,39 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
+dependencies = [
+ "crossbeam-epoch 0.8.2",
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch",
+ "crossbeam-epoch 0.9.15",
  "crossbeam-utils 0.8.16",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+dependencies = [
+ "autocfg",
+ "cfg-if 0.1.10",
+ "crossbeam-utils 0.7.2",
+ "lazy_static",
+ "maybe-uninit",
+ "memoffset 0.5.6",
+ "scopeguard",
 ]
 
 [[package]]
@@ -1403,6 +1429,17 @@ dependencies = [
  "crossbeam-utils 0.8.16",
  "memoffset 0.9.0",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+dependencies = [
+ "cfg-if 0.1.10",
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -1480,7 +1517,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
- "quote",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -1522,8 +1559,8 @@ checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -1536,8 +1573,8 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -1550,8 +1587,8 @@ checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "strsim 0.10.0",
  "syn 2.0.39",
 ]
@@ -1563,7 +1600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1574,7 +1611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core 0.14.4",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1585,7 +1622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -1688,8 +1725,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
  "darling 0.14.4",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1710,8 +1747,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
@@ -1749,7 +1786,7 @@ dependencies = [
  "sqlx",
  "storyteller_root",
  "tokens",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -1770,7 +1807,7 @@ dependencies = [
  "mysql_queries",
  "sqlx",
  "tokens",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -1783,8 +1820,8 @@ dependencies = [
  "byteorder",
  "diesel_derives",
  "mysqlclient-sys",
- "percent-encoding",
- "url",
+ "percent-encoding 2.3.1",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -1794,8 +1831,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8337737574f55a468005a83499da720f20c65586241ffea339db9ecdfd2b44"
 dependencies = [
  "diesel_table_macro_syntax",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -1870,8 +1907,8 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -1934,7 +1971,7 @@ dependencies = [
  "subprocess",
  "subprocess_common",
  "tempdir",
- "tokio",
+ "tokio 1.34.0",
  "zip",
 ]
 
@@ -1980,7 +2017,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -2025,13 +2062,13 @@ dependencies = [
  "bytes 1.5.0",
  "dyn-clone",
  "lazy_static",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "reqwest",
  "rustc_version 0.2.3",
  "serde",
  "serde_json",
  "serde_with",
- "url",
+ "url 2.5.0",
  "void",
 ]
 
@@ -2057,7 +2094,7 @@ dependencies = [
  "storyteller_root",
  "strum",
  "tokens",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -2132,7 +2169,7 @@ dependencies = [
  "tempdir",
  "testing",
  "tokens",
- "tokio",
+ "tokio 1.34.0",
  "tts_common",
 ]
 
@@ -2341,7 +2378,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.3.1",
 ]
 
 [[package]]
@@ -2469,8 +2506,8 @@ version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -2596,7 +2633,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 1.34.0",
  "tokio-util",
  "tracing",
 ]
@@ -2737,8 +2774,8 @@ dependencies = [
  "log",
  "mac",
  "markup5ever",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -2788,7 +2825,7 @@ dependencies = [
  "serde_json",
  "serde_qs 0.8.5",
  "serde_urlencoded",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -2851,7 +2888,7 @@ dependencies = [
  "itoa 1.0.9",
  "pin-project-lite",
  "socket2 0.4.10",
- "tokio",
+ "tokio 1.34.0",
  "tower-service",
  "tracing",
  "want",
@@ -2866,7 +2903,7 @@ dependencies = [
  "bytes 1.5.0",
  "hyper",
  "native-tls",
- "tokio",
+ "tokio 1.34.0",
  "tokio-native-tls",
 ]
 
@@ -2906,6 +2943,17 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "idna"
@@ -3025,7 +3073,7 @@ dependencies = [
  "subprocess_common",
  "tempdir",
  "tokens",
- "tokio",
+ "tokio 1.34.0",
  "tts_common",
 ]
 
@@ -3071,6 +3119,15 @@ dependencies = [
  "hermit-abi 0.3.3",
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -3218,15 +3275,15 @@ dependencies = [
  "futures-util",
  "hostname",
  "httpdate",
- "idna",
+ "idna 0.5.0",
  "mime",
  "native-tls",
  "nom",
  "once_cell",
  "quoted_printable",
  "socket2 0.5.5",
- "tokio",
- "url",
+ "tokio 1.34.0",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -3284,13 +3341,13 @@ dependencies = [
 [[package]]
 name = "limitation"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e415413963930f7050f21994bfd336dc75ef8b5b3b142e99c55b72b61f726d5"
 dependencies = [
  "chrono",
  "futures 0.1.31",
  "redis 0.13.0",
  "time 0.1.45",
+ "tokio 0.1.22",
+ "version-sync",
 ]
 
 [[package]]
@@ -3427,13 +3484,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
 name = "maybe-async"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -3485,6 +3548,15 @@ name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "memoffset"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "memoffset"
@@ -3639,8 +3711,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if 1.0.0",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -3718,13 +3790,13 @@ dependencies = [
  "syn 2.0.39",
  "time 0.3.30",
  "time-macros",
- "tokio",
+ "tokio 1.34.0",
  "tokio-stream",
  "tracing",
  "twitch_oauth2",
  "unicode-bidi",
  "unicode-normalization",
- "url",
+ "url 2.5.0",
  "void",
  "winapi 0.3.9",
  "windows-sys 0.48.0",
@@ -3754,7 +3826,7 @@ dependencies = [
  "serial_test",
  "sqlx",
  "tokens",
- "tokio",
+ "tokio 1.34.0",
  "toml",
 ]
 
@@ -3824,7 +3896,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 1.34.0",
  "uuid 0.8.2",
 ]
 
@@ -4027,8 +4099,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -4180,6 +4252,12 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+
+[[package]]
+name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
@@ -4241,8 +4319,8 @@ checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
 dependencies = [
  "phf_generator 0.11.2",
  "phf_shared 0.11.2",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -4279,8 +4357,8 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -4391,8 +4469,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
  "version_check",
 ]
@@ -4403,9 +4481,18 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4424,6 +4511,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1b74cc784b038a9921fd1a48310cc2e238101aa8ae0b94201e2d85121dd68b5"
+dependencies = [
+ "bitflags 1.3.2",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -4469,11 +4567,20 @@ dependencies = [
 
 [[package]]
 name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
+]
+
+[[package]]
+name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.69",
 ]
 
 [[package]]
@@ -4618,7 +4725,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-deque",
+ "crossbeam-deque 0.8.3",
  "crossbeam-utils 0.8.16",
 ]
 
@@ -4642,7 +4749,7 @@ dependencies = [
  "dtoa 0.4.8",
  "futures 0.1.31",
  "itoa 0.4.8",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "sha1 0.6.1",
  "tokio-codec",
  "tokio-executor",
@@ -4650,7 +4757,7 @@ dependencies = [
  "tokio-sync",
  "tokio-tcp",
  "tokio-uds",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -4663,9 +4770,9 @@ dependencies = [
  "combine 4.6.6",
  "dtoa 0.4.8",
  "itoa 0.4.8",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "sha1 0.6.1",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -4679,13 +4786,13 @@ dependencies = [
  "combine 4.6.6",
  "futures-util",
  "itoa 1.0.9",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "ryu",
  "sha1 0.6.1",
- "tokio",
+ "tokio 1.34.0",
  "tokio-util",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -4800,17 +4907,17 @@ dependencies = [
  "mime",
  "native-tls",
  "once_cell",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
- "tokio",
+ "tokio 1.34.0",
  "tokio-native-tls",
  "tokio-util",
  "tower-service",
- "url",
+ "url 2.5.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
@@ -4908,8 +5015,8 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3d8c6fd84090ae348e63a84336b112b5c3918b3bf0493a581f7bd8ee623c29"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "rust-embed-utils",
  "shellexpand",
  "syn 2.0.39",
@@ -4956,7 +5063,7 @@ dependencies = [
  "maybe-async",
  "md5",
  "minidom",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "quick-xml 0.26.0",
  "reqwest",
  "serde",
@@ -4964,9 +5071,9 @@ dependencies = [
  "sha2 0.10.8",
  "thiserror",
  "time 0.3.30",
- "tokio",
+ "tokio 1.34.0",
  "tokio-stream",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -5136,7 +5243,7 @@ dependencies = [
  "clap 2.34.0",
  "errors",
  "my-workspace-hack",
- "tokio",
+ "tokio 1.34.0",
  "web_scrapers",
 ]
 
@@ -5225,7 +5332,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
 ]
 
 [[package]]
@@ -5239,6 +5346,12 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46e1121e8180c12ff69a742aabc4f310542b6ccb69f1691689ac17fdf8618aa"
 
 [[package]]
 name = "serde"
@@ -5255,8 +5368,8 @@ version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -5296,7 +5409,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "serde",
  "thiserror",
 ]
@@ -5307,7 +5420,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cac3f1e2ca2fe333923a1ae72caca910b98ed0630bb35ef6f8c8517d6e81afa"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "serde",
  "thiserror",
 ]
@@ -5318,8 +5431,8 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -5352,8 +5465,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
  "darling 0.13.4",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -5377,8 +5490,8 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -5531,8 +5644,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -5646,7 +5759,7 @@ dependencies = [
  "bytes 1.5.0",
  "chrono",
  "crc",
- "crossbeam-queue",
+ "crossbeam-queue 0.3.8",
  "dotenvy",
  "either",
  "event-listener",
@@ -5663,7 +5776,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "paste",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "rustls 0.21.9",
  "rustls-pemfile",
  "serde",
@@ -5672,10 +5785,10 @@ dependencies = [
  "smallvec 1.11.2",
  "sqlformat",
  "thiserror",
- "tokio",
+ "tokio 1.34.0",
  "tokio-stream",
  "tracing",
- "url",
+ "url 2.5.0",
  "webpki-roots 0.25.3",
 ]
 
@@ -5685,8 +5798,8 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89961c00dc4d7dffb7aee214964b065072bff69e36ddb9e2c107541f75e4f2a5"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "sqlx-core",
  "sqlx-macros-core",
  "syn 1.0.109",
@@ -5704,8 +5817,8 @@ dependencies = [
  "heck",
  "hex",
  "once_cell",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -5715,8 +5828,8 @@ dependencies = [
  "sqlx-sqlite",
  "syn 1.0.109",
  "tempfile",
- "tokio",
- "url",
+ "tokio 1.34.0",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -5748,7 +5861,7 @@ dependencies = [
  "md-5 0.10.6",
  "memchr",
  "once_cell",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "rand 0.8.5",
  "rsa",
  "serde",
@@ -5818,11 +5931,11 @@ dependencies = [
  "futures-util",
  "libsqlite3-sys",
  "log",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "serde",
  "sqlx-core",
  "tracing",
- "url",
+ "url 2.5.0",
  "urlencoding",
 ]
 
@@ -5925,7 +6038,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "pin-project-lite",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.3",
  "r2d2_redis",
  "rand 0.8.5",
  "redis_caching",
@@ -5945,7 +6058,7 @@ dependencies = [
  "symphonia",
  "time 0.3.30",
  "tokens",
- "tokio",
+ "tokio 1.34.0",
  "toml",
  "tts_common",
  "twitch_common",
@@ -5989,8 +6102,8 @@ checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
 dependencies = [
  "phf_generator 0.10.0",
  "phf_shared 0.10.0",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
 ]
 
 [[package]]
@@ -6032,8 +6145,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "rustversion",
  "syn 2.0.39",
 ]
@@ -6231,12 +6344,23 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "unicode-ident",
 ]
 
@@ -6246,8 +6370,8 @@ version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "unicode-ident",
 ]
 
@@ -6353,8 +6477,8 @@ version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -6453,6 +6577,30 @@ dependencies = [
 
 [[package]]
 name = "tokio"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
+dependencies = [
+ "bytes 0.4.12",
+ "futures 0.1.31",
+ "mio 0.6.23",
+ "num_cpus",
+ "tokio-codec",
+ "tokio-current-thread",
+ "tokio-executor",
+ "tokio-fs",
+ "tokio-io",
+ "tokio-reactor",
+ "tokio-sync",
+ "tokio-tcp",
+ "tokio-threadpool",
+ "tokio-timer",
+ "tokio-udp",
+ "tokio-uds",
+]
+
+[[package]]
+name = "tokio"
 version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
@@ -6482,6 +6630,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-current-thread"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
+dependencies = [
+ "futures 0.1.31",
+ "tokio-executor",
+]
+
+[[package]]
 name = "tokio-executor"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6489,6 +6647,17 @@ checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.31",
+]
+
+[[package]]
+name = "tokio-fs"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
+dependencies = [
+ "futures 0.1.31",
+ "tokio-io",
+ "tokio-threadpool",
 ]
 
 [[package]]
@@ -6508,8 +6677,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -6520,7 +6689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -6549,7 +6718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls 0.19.1",
- "tokio",
+ "tokio 1.34.0",
  "webpki",
 ]
 
@@ -6561,7 +6730,7 @@ checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -6589,6 +6758,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-threadpool"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
+dependencies = [
+ "crossbeam-deque 0.7.4",
+ "crossbeam-queue 0.2.3",
+ "crossbeam-utils 0.7.2",
+ "futures 0.1.31",
+ "lazy_static",
+ "log",
+ "num_cpus",
+ "slab",
+ "tokio-executor",
+]
+
+[[package]]
+name = "tokio-timer"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
+dependencies = [
+ "crossbeam-utils 0.7.2",
+ "futures 0.1.31",
+ "slab",
+ "tokio-executor",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6598,11 +6796,26 @@ dependencies = [
  "log",
  "pin-project",
  "rustls 0.19.1",
- "tokio",
+ "tokio 1.34.0",
  "tokio-rustls",
  "tungstenite",
  "webpki",
  "webpki-roots 0.21.1",
+]
+
+[[package]]
+name = "tokio-udp"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
+dependencies = [
+ "bytes 0.4.12",
+ "futures 0.1.31",
+ "log",
+ "mio 0.6.23",
+ "tokio-codec",
+ "tokio-io",
+ "tokio-reactor",
 ]
 
 [[package]]
@@ -6633,7 +6846,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
- "tokio",
+ "tokio 1.34.0",
  "tracing",
 ]
 
@@ -6670,8 +6883,8 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 
@@ -6718,7 +6931,7 @@ dependencies = [
  "sqlx",
  "subprocess",
  "tempdir",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -6752,7 +6965,7 @@ dependencies = [
  "sqlx",
  "subprocess",
  "tempdir",
- "tokio",
+ "tokio 1.34.0",
  "tts_common",
 ]
 
@@ -6790,7 +7003,7 @@ dependencies = [
  "rustls-native-certs",
  "sha-1",
  "thiserror",
- "url",
+ "url 2.5.0",
  "utf-8",
  "webpki",
 ]
@@ -6820,7 +7033,7 @@ dependencies = [
  "my-workspace-hack",
  "mysql_queries",
  "native-tls",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.3",
  "r2d2_redis",
  "rand 0.8.5",
  "redis_common",
@@ -6833,7 +7046,7 @@ dependencies = [
  "sqlx",
  "time 0.3.30",
  "tokens",
- "tokio",
+ "tokio 1.34.0",
  "tokio-tungstenite",
  "toml",
  "tts_common",
@@ -6865,7 +7078,7 @@ dependencies = [
  "thiserror",
  "twitch_oauth2",
  "typed-builder",
- "url",
+ "url 2.5.0",
  "version_check",
 ]
 
@@ -6901,7 +7114,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -6910,8 +7123,8 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a46ee5bd706ff79131be9c94e7edcb82b703c487766a114434e5790361cf08c5"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -6964,6 +7177,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6992,13 +7211,24 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+dependencies = [
+ "idna 0.1.5",
+ "matches",
+ "percent-encoding 1.0.1",
+]
+
+[[package]]
+name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
- "percent-encoding",
+ "idna 0.5.0",
+ "percent-encoding 2.3.1",
  "serde",
 ]
 
@@ -7025,7 +7255,7 @@ version = "0.0.1"
 dependencies = [
  "my-workspace-hack",
  "once_cell",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.3",
  "regex",
  "unicode-segmentation",
 ]
@@ -7106,8 +7336,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0b6f4667edd64be0e820d6631a60433a269710b6ee89ac39525b872b76d61d"
 dependencies = [
  "proc-macro-error",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "regex",
  "syn 2.0.39",
 ]
@@ -7156,6 +7386,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "version-sync"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "844f3d3a2467f15cb999f5af7775f6e108ac546d4f42365832ed4c755404f806"
+dependencies = [
+ "itertools 0.8.2",
+ "proc-macro2 0.4.30",
+ "pulldown-cmark 0.4.1",
+ "regex",
+ "semver-parser 0.9.0",
+ "syn 0.15.44",
+ "toml",
+ "url 1.7.2",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7195,7 +7441,7 @@ dependencies = [
  "sqlx",
  "subprocess",
  "tempdir",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -7224,7 +7470,7 @@ dependencies = [
  "sqlx",
  "subprocess",
  "tempdir",
- "tokio",
+ "tokio 1.34.0",
 ]
 
 [[package]]
@@ -7289,8 +7535,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
@@ -7313,7 +7559,7 @@ version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
- "quote",
+ "quote 1.0.33",
  "wasm-bindgen-macro-support",
 ]
 
@@ -7323,8 +7569,8 @@ version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -7453,7 +7699,7 @@ dependencies = [
  "sha2 0.9.9",
  "sqlx",
  "time 0.3.30",
- "tokio",
+ "tokio 1.34.0",
  "toml",
  "twitch_api2",
  "twitch_common",
@@ -7692,8 +7938,8 @@ version = "0.7.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 2.0.39",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ members = [
   "crates/service/plugins/users",
 
   # Vendored code
+  "crates/vendor/limitation",
   "crates/vendor/newrelic-telemetry-sdk-rust",
 
   # Vendored code

--- a/crates/service/web/storyteller_web/Cargo.toml
+++ b/crates/service/web/storyteller_web/Cargo.toml
@@ -104,7 +104,7 @@ pin-project-lite = "0.2.9" # NB: For middleware/futures upgrade
 sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-rustls", "chrono" ] }
 
 # Redis Database
-limitation = "0.1.1" # Redis rate limiter
+limitation = { path = "../../../vendor/limitation" }
 r2d2_redis = "0.14.0"
 
 # Elasticsearch

--- a/crates/service/web/websocket_gateway/Cargo.toml
+++ b/crates/service/web/websocket_gateway/Cargo.toml
@@ -50,7 +50,7 @@ futures_old_for_limiter = { package = "futures", version = "0.1.29" } # Older ve
 sqlx = { version = "0.7.2", features = [ "mysql", "runtime-tokio", "tls-rustls", "chrono" ] }
 
 # Redis Database
-limitation = "0.1.1" # Redis rate limiter
+limitation = { path = "../../../vendor/limitation" }
 r2d2_redis = "0.14.0"
 redis_async = { package = "redis", version = "0.21.5", features = ["tokio-comp"] }
 

--- a/crates/vendor/limitation/CHANGELOG.md
+++ b/crates/vendor/limitation/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unreleased
+
+## 0.1.1 / 2019-10-20
+
+### Improvements
+
+- Add `readme` to `Cargo.toml` (@fnichol)
+
+## 0.1.0 / 2019-10-20
+
+- The initial release.

--- a/crates/vendor/limitation/CODE_OF_CONDUCT.md
+++ b/crates/vendor/limitation/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at fnichol@nichol.ca. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq
+

--- a/crates/vendor/limitation/Cargo.toml
+++ b/crates/vendor/limitation/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "limitation"
+version = "0.1.1"
+authors = ["Fletcher Nichol <fnichol@nichol.ca>"]
+edition = "2018"
+license = "MPL-2.0"
+repository = "https://github.com/fnichol/limitation"
+documentation = "https://docs.rs/limitation"
+readme = "README.md"
+keywords = ["rate-limit", "rate-limiting", "limiter", "redis"]
+categories = ["asynchronous", "web-programming"]
+description = """
+A rate limiter using a fixed window counter for arbitrary keys, backed by
+Redis.
+"""
+
+[badges]
+cirrus-ci = { repository = "fnichol/limitation" }
+
+[dependencies]
+chrono = "0.4.9"
+futures = "0.1.29"
+redis = "0.13.0"
+time = "0.1.42"
+
+[dev-dependencies]
+tokio = "0.1.22"
+version-sync = "0.8.1"

--- a/crates/vendor/limitation/LICENSE.txt
+++ b/crates/vendor/limitation/LICENSE.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/crates/vendor/limitation/Makefile.toml
+++ b/crates/vendor/limitation/Makefile.toml
@@ -1,0 +1,6 @@
+[tasks.member-readme]
+dependencies = [
+  "generate-readme",
+  "update-readme-toc",
+  "format-readme",
+]

--- a/crates/vendor/limitation/README.md
+++ b/crates/vendor/limitation/README.md
@@ -1,0 +1,298 @@
+# limitation
+
+|                 |                                             |
+| --------------: | ------------------------------------------- |
+|              CI | [![CI Status][badge-ci-overall]][ci]        |
+|  Latest Version | [![Latest version][badge-version]][crate]   |
+|   Documentation | [![Documentation][badge-docs]][docs]        |
+| Crate Downloads | [![Crate downloads][badge-crate-dl]][crate] |
+|         License | [![Crate license][badge-license]][github]   |
+
+**Table of Contents**
+
+<!-- toc -->
+
+- [About](#about)
+- [Usage](#usage)
+  - [Quick Example](#quick-example)
+  - [The Limiter Builder](#the-limiter-builder)
+- [Examples](#examples)
+- [Related Projects and References](#related-projects-and-references)
+- [Ideas and Future Work](#ideas-and-future-work)
+- [CI Status](#ci-status)
+  - [Build (master branch)](#build-master-branch)
+  - [Test (master branch)](#test-master-branch)
+  - [Check (master branch)](#check-master-branch)
+- [Code of Conduct](#code-of-conduct)
+- [Issues](#issues)
+- [Contributing](#contributing)
+- [Release History](#release-history)
+- [Authors](#authors)
+- [License](#license)
+
+<!-- tocstop -->
+
+A rate limiter using a fixed window counter for arbitrary keys, backed by Redis.
+
+## About
+
+This library provides a fixed window counter for arbitrary keys backed by a
+Redis instance. The period length and per-period maximum limit are configurable
+on setup. The communication with the backend is performing in a non-blocking,
+asynchronous fashion allowing the library to pair with other async frameworks
+such as Tokio, Actix, etc.
+
+_Note_: Currently pre-_async/await_ Futures are used (that is Futures 0.1.x) but
+that may be upgraded in the near future as the Rust 1.39.0 release is near.
+
+## Usage
+
+Add `limitation` to your `Cargo.toml`:
+
+```toml
+[dependencies]
+limitation = "0.1.1"
+```
+
+### Quick Example
+
+The primary type is the [`Limiter`] which uses a builder to construct itself.
+Once built, use the [`count`] method with a key representing a user, a session,
+an interaction, etc. Note that `count` is a Future and therefore has to be
+driving to completion with a runtime. For example, to run one count on a key of
+`"10.0.0.5"`:
+
+[`limiter`]: struct.Limiter.html
+[`count`]: struct.Limiter.html#method.count
+
+```rust
+use limitation::Limiter;
+use futures::Future;
+
+// Build a Limiter with a default rate with a local running Redis instance
+let limiter = Limiter::build("redis://127.0.0.1/").finish()?;
+// The key to count and track
+let key = "10.0.0.5";
+
+// Start and run a Tokio runtime to drive the Future to completion
+tokio::run(
+    limiter
+        // Count returns a Status if the key is under the limit and an `Error::LimitExceeded`
+        // containing a Status if the limit has been exceeded
+        .count(key)
+        // This example deals with both limit exceeded and any Redis connection issues. In this
+        // case we'll print the error to the standard error stream to show the current limit
+        // status
+        .map_err(|err| eprintln!("err: {}", err))
+        // In this case we are under the limit and can print out the limit status to the
+        // standard output stream
+        .and_then(|status| {
+            println!("ok: {:?}", status);
+            Ok(())
+        }),
+);
+```
+
+### The Limiter Builder
+
+The builder for the `Limiter` has 2 settings which can be customized to the use
+case:
+
+- [`limit`]: The high water mark for number of requests in the period. The
+  default is `5000`.
+- [`period`]: A `Duration` for the period window. The default is 60 minutes.
+
+```rust
+use limitation::Limiter;
+use std::time::Duration;
+
+let limiter = Limiter::build("redis://127.0.0.1/")
+    .limit(5)
+    .period(Duration::from_secs(10))
+    .finish()?;
+```
+
+[`limit`]: struct.Builder.html#method.limit
+[`period`]: struct.Builder.html#method.period
+
+## Examples
+
+A simple example that uses this library can be found in [limitation-example].
+
+[limitation-example]:
+  https://github.com/fnichol/limitation/tree/master/limitation-example
+
+## Related Projects and References
+
+The primary inspiration for the implementation was a blog post called [An
+alternative approach to building a simple API Rate limiter using NodeJS and
+Redis][blog-post] by [Atul R](https://twitter.com/masteratul94).
+
+Other research and references used for this library:
+
+- <https://nordicapis.com/everything-you-need-to-know-about-api-rate-limiting/>
+- <https://hechao.li/2018/06/25/Rate-Limiter-Part1/>
+- <https://www.figma.com/blog/an-alternative-approach-to-rate-limiting/>
+- <https://engagor.github.io/blog/2017/05/02/sliding-window-rate-limiter-redis/>
+
+[blog-post]: https://blog.atulr.com/rate-limiter/
+
+## Ideas and Future Work
+
+These are some ideas and potential future work for this project. If you're
+reading this then maybe you're curious or interesting in helping out? Great! Be
+sure to check out the [Contributing] section and dig in!
+
+- Investigate and offer alternative rate-limiting algorithms, notably a Sliding
+  Window solution.
+- Add async Redis connection pooling with the `bb8` and `bb8-redis` crates to
+  reduce connection establishment delays.
+- Add a `status` method on `Limiter` which returns they key's `Status` without
+  counting a request.
+- Add `RedisServer` support in an integration testing suite, similar to the
+  infrastructure in the [redis] crate.
+
+[contributing]:
+  https://github.com/fnichol/limitation/tree/master/limitation#contributing
+[redis]: https://github.com/mitsuhiko/redis-rs/blob/master/tests/support/mod.rs
+
+## CI Status
+
+### Build (master branch)
+
+| Operating System | Stable Rust                                                             | Nightly Rust                                                              | <abbr title="Minimum Supported Rust Version">MSRV</abbr>                |
+| ---------------: | ----------------------------------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+|          FreeBSD | [![FreeBSD Stable Build Status][badge-stable_freebsd-build]][ci-master] | [![FreeBSD Nightly Build Status][badge-nightly_freebsd-build]][ci-master] | [![FreeBSD Oldest Build Status][badge-oldest_freebsd-build]][ci-master] |
+|            Linux | [![Linux Stable Build Status][badge-stable_linux-build]][ci-master]     | [![Linux Nightly Build Status][badge-nightly_linux-build]][ci-master]     | [![Linux Oldest Build Status][badge-oldest_linux-build]][ci-master]     |
+|            macOS | [![macOS Stable Build Status][badge-stable_macos-build]][ci-master]     | [![macOS Nightly Build Status][badge-nightly_macos-build]][ci-master]     | [![macOS Oldest Build Status][badge-oldest_macos-build]][ci-master]     |
+|          Windows | [![Windows Stable Build Status][badge-stable_windows-build]][ci-master] | [![Windows Nightly Build Status][badge-nightly_windows-build]][ci-master] | [![Windows Oldest Build Status][badge-oldest_windows-build]][ci-master] |
+
+### Test (master branch)
+
+| Operating System | Stable Rust                                                           | Nightly Rust                                                            | <abbr title="Minimum Supported Rust Version">MSRV</abbr>              |
+| ---------------: | --------------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
+|          FreeBSD | [![FreeBSD Stable Test Status][badge-stable_freebsd-test]][ci-master] | [![FreeBSD Nightly Test Status][badge-nightly_freebsd-test]][ci-master] | [![FreeBSD Oldest Test Status][badge-oldest_freebsd-test]][ci-master] |
+|            Linux | [![Linux Stable Test Status][badge-stable_linux-test]][ci-master]     | [![Linux Nightly Test Status][badge-nightly_linux-test]][ci-master]     | [![Linux Oldest Test Status][badge-oldest_linux-test]][ci-master]     |
+|            macOS | [![macOS Stable Test Status][badge-stable_macos-test]][ci-master]     | [![macOS Nightly Test Status][badge-nightly_macos-test]][ci-master]     | [![macOS Oldest Test Status][badge-oldest_macos-test]][ci-master]     |
+|          Windows | [![Windows Stable Test Status][badge-stable_windows-test]][ci-master] | [![Windows Nightly Test Status][badge-nightly_windows-test]][ci-master] | [![Windows Oldest Test Status][badge-oldest_windows-test]][ci-master] |
+
+### Check (master branch)
+
+|        | Status                                            |
+| ------ | ------------------------------------------------- |
+| Lint   | [![Lint Status][badge-check-lint]][ci-master]     |
+| Format | [![Format Status][badge-check-format]][ci-master] |
+
+## Code of Conduct
+
+This project adheres to the Contributor Covenant [code of
+conduct][code-of-conduct]. By participating, you are expected to uphold this
+code. Please report unacceptable behavior to fnichol@nichol.ca.
+
+## Issues
+
+If you have any problems with or questions about this project, please contact us
+through a [GitHub issue][issues].
+
+## Contributing
+
+You are invited to contribute to new features, fixes, or updates, large or
+small; we are always thrilled to receive pull requests, and do our best to
+process them as fast as we can.
+
+Before you start to code, we recommend discussing your plans through a [GitHub
+issue][issues], especially for more ambitious contributions. This gives other
+contributors a chance to point you in the right direction, give you feedback on
+your design, and help you find out if someone else is working on the same thing.
+
+## Release History
+
+See the [changelog] for a full release history.
+
+## Authors
+
+Created and maintained by [Fletcher Nichol][fnichol] (<fnichol@nichol.ca>).
+
+## License
+
+Licensed under the Mozilla Public License Version 2.0 ([LICENSE.txt][license]).
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the MPL-2.0 license, shall be
+licensed as above, without any additional terms or conditions.
+
+[badge-check-format]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=check&script=format
+[badge-check-lint]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=check&script=lint
+[badge-ci-overall]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square
+[badge-crate-dl]:
+  https://img.shields.io/crates/d/limitation.svg?style=flat-square
+[badge-docs]: https://docs.rs/limitation/badge.svg?style=flat-square
+[badge-license]:
+  https://img.shields.io/crates/l/limitation.svg?style=flat-square
+[badge-nightly_freebsd-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_freebsd&script=build
+[badge-nightly_freebsd-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_freebsd&script=test
+[badge-nightly_linux-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_linux&script=build
+[badge-nightly_linux-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_linux&script=test
+[badge-nightly_macos-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_macos&script=build
+[badge-nightly_macos-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_macos&script=test
+[badge-nightly_windows-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_windows&script=build
+[badge-nightly_windows-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_windows&script=test
+[badge-oldest_freebsd-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_freebsd&script=build
+[badge-oldest_freebsd-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_freebsd&script=test
+[badge-oldest_linux-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_linux&script=build
+[badge-oldest_linux-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_linux&script=test
+[badge-oldest_macos-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_macos&script=build
+[badge-oldest_macos-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_macos&script=test
+[badge-oldest_windows-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_windows&script=build
+[badge-oldest_windows-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_windows&script=test
+[badge-stable_freebsd-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_freebsd&script=build
+[badge-stable_freebsd-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_freebsd&script=test
+[badge-stable_linux-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_linux&script=build
+[badge-stable_linux-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_linux&script=test
+[badge-stable_macos-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_macos&script=build
+[badge-stable_macos-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_macos&script=test
+[badge-stable_windows-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_windows&script=build
+[badge-stable_windows-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_windows&script=test
+[badge-version]:
+  https://img.shields.io/crates/v/limitation.svg?style=flat-square
+[changelog]:
+  https://github.com/fnichol/limitation/blob/master/limitation/CHANGELOG.md
+[ci]: https://cirrus-ci.com/github/fnichol/limitation
+[ci-master]: https://cirrus-ci.com/github/fnichol/limitation/master
+[code-of-conduct]:
+  https://github.com/fnichol/limitation/blob/master/limitation/CODE_OF_CONDUCT.md
+[commonmark]: https://commonmark.org/
+[crate]: https://crates.io/crates/limitation
+[docs]: https://docs.rs/limitation
+[fnichol]: https://github.com/fnichol
+[github]: https://github.com/fnichol/limitation
+[issues]: https://github.com/fnichol/limitation/issues
+[license]:
+  https://github.com/fnichol/limitation/blob/master/limitation/LICENSE.txt

--- a/crates/vendor/limitation/README.tpl
+++ b/crates/vendor/limitation/README.tpl
@@ -1,0 +1,156 @@
+# {{crate}}
+
+|                 |                                             |
+| --------------: | ------------------------------------------- |
+|              CI | [![CI Status][badge-ci-overall]][ci]        |
+|  Latest Version | [![Latest version][badge-version]][crate]   |
+|   Documentation | [![Documentation][badge-docs]][docs]        |
+| Crate Downloads | [![Crate downloads][badge-crate-dl]][crate] |
+|         License | [![Crate license][badge-license]][github]   |
+
+**Table of Contents**
+
+<!-- toc -->
+
+{{readme}}
+
+## CI Status
+
+### Build (master branch)
+
+| Operating System | Stable Rust                                                             | Nightly Rust                                                              | <abbr title="Minimum Supported Rust Version">MSRV</abbr>                |
+| ---------------: | ----------------------------------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+|          FreeBSD | [![FreeBSD Stable Build Status][badge-stable_freebsd-build]][ci-master] | [![FreeBSD Nightly Build Status][badge-nightly_freebsd-build]][ci-master] | [![FreeBSD Oldest Build Status][badge-oldest_freebsd-build]][ci-master] |
+|            Linux | [![Linux Stable Build Status][badge-stable_linux-build]][ci-master]     | [![Linux Nightly Build Status][badge-nightly_linux-build]][ci-master]     | [![Linux Oldest Build Status][badge-oldest_linux-build]][ci-master]     |
+|            macOS | [![macOS Stable Build Status][badge-stable_macos-build]][ci-master]     | [![macOS Nightly Build Status][badge-nightly_macos-build]][ci-master]     | [![macOS Oldest Build Status][badge-oldest_macos-build]][ci-master]     |
+|          Windows | [![Windows Stable Build Status][badge-stable_windows-build]][ci-master] | [![Windows Nightly Build Status][badge-nightly_windows-build]][ci-master] | [![Windows Oldest Build Status][badge-oldest_windows-build]][ci-master] |
+
+### Test (master branch)
+
+| Operating System | Stable Rust                                                           | Nightly Rust                                                            | <abbr title="Minimum Supported Rust Version">MSRV</abbr>              |
+| ---------------: | --------------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
+|          FreeBSD | [![FreeBSD Stable Test Status][badge-stable_freebsd-test]][ci-master] | [![FreeBSD Nightly Test Status][badge-nightly_freebsd-test]][ci-master] | [![FreeBSD Oldest Test Status][badge-oldest_freebsd-test]][ci-master] |
+|            Linux | [![Linux Stable Test Status][badge-stable_linux-test]][ci-master]     | [![Linux Nightly Test Status][badge-nightly_linux-test]][ci-master]     | [![Linux Oldest Test Status][badge-oldest_linux-test]][ci-master]     |
+|            macOS | [![macOS Stable Test Status][badge-stable_macos-test]][ci-master]     | [![macOS Nightly Test Status][badge-nightly_macos-test]][ci-master]     | [![macOS Oldest Test Status][badge-oldest_macos-test]][ci-master]     |
+|          Windows | [![Windows Stable Test Status][badge-stable_windows-test]][ci-master] | [![Windows Nightly Test Status][badge-nightly_windows-test]][ci-master] | [![Windows Oldest Test Status][badge-oldest_windows-test]][ci-master] |
+
+### Check (master branch)
+
+|        | Status                                            |
+| ------ | ------------------------------------------------- |
+| Lint   | [![Lint Status][badge-check-lint]][ci-master]     |
+| Format | [![Format Status][badge-check-format]][ci-master] |
+
+## Code of Conduct
+
+This project adheres to the Contributor Covenant [code of
+conduct][code-of-conduct]. By participating, you are expected to uphold this
+code. Please report unacceptable behavior to fnichol@nichol.ca.
+
+## Issues
+
+If you have any problems with or questions about this project, please contact us
+through a [GitHub issue][issues].
+
+## Contributing
+
+You are invited to contribute to new features, fixes, or updates, large or
+small; we are always thrilled to receive pull requests, and do our best to
+process them as fast as we can.
+
+Before you start to code, we recommend discussing your plans through a [GitHub
+issue][issues], especially for more ambitious contributions. This gives other
+contributors a chance to point you in the right direction, give you feedback on
+your design, and help you find out if someone else is working on the same thing.
+
+## Release History
+
+See the [changelog] for a full release history.
+
+## Authors
+
+Created and maintained by [Fletcher Nichol][fnichol] (<fnichol@nichol.ca>).
+
+## License
+
+Licensed under the Mozilla Public License Version 2.0 ([LICENSE.txt][license]).
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the MPL-2.0 license, shall be
+licensed as above, without any additional terms or conditions.
+
+[badge-check-format]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=check&script=format
+[badge-check-lint]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=check&script=lint
+[badge-ci-overall]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square
+[badge-crate-dl]:
+  https://img.shields.io/crates/d/limitation.svg?style=flat-square
+[badge-docs]: https://docs.rs/limitation/badge.svg?style=flat-square
+[badge-license]:
+  https://img.shields.io/crates/l/limitation.svg?style=flat-square
+[badge-nightly_freebsd-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_freebsd&script=build
+[badge-nightly_freebsd-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_freebsd&script=test
+[badge-nightly_linux-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_linux&script=build
+[badge-nightly_linux-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_linux&script=test
+[badge-nightly_macos-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_macos&script=build
+[badge-nightly_macos-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_macos&script=test
+[badge-nightly_windows-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_windows&script=build
+[badge-nightly_windows-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_nightly_windows&script=test
+[badge-oldest_freebsd-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_freebsd&script=build
+[badge-oldest_freebsd-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_freebsd&script=test
+[badge-oldest_linux-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_linux&script=build
+[badge-oldest_linux-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_linux&script=test
+[badge-oldest_macos-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_macos&script=build
+[badge-oldest_macos-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_macos&script=test
+[badge-oldest_windows-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_windows&script=build
+[badge-oldest_windows-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_1.35.0_windows&script=test
+[badge-stable_freebsd-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_freebsd&script=build
+[badge-stable_freebsd-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_freebsd&script=test
+[badge-stable_linux-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_linux&script=build
+[badge-stable_linux-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_linux&script=test
+[badge-stable_macos-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_macos&script=build
+[badge-stable_macos-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_macos&script=test
+[badge-stable_windows-build]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_windows&script=build
+[badge-stable_windows-test]:
+  https://img.shields.io/cirrus/github/fnichol/limitation.svg?style=flat-square&task=test_stable_windows&script=test
+[badge-version]:
+  https://img.shields.io/crates/v/limitation.svg?style=flat-square
+[changelog]:
+  https://github.com/fnichol/limitation/blob/master/limitation/CHANGELOG.md
+[ci]: https://cirrus-ci.com/github/fnichol/limitation
+[ci-master]: https://cirrus-ci.com/github/fnichol/limitation/master
+[code-of-conduct]:
+  https://github.com/fnichol/limitation/blob/master/limitation/CODE_OF_CONDUCT.md
+[commonmark]: https://commonmark.org/
+[crate]: https://crates.io/crates/limitation
+[docs]: https://docs.rs/limitation
+[fnichol]: https://github.com/fnichol
+[github]: https://github.com/fnichol/limitation
+[issues]: https://github.com/fnichol/limitation/issues
+[license]:
+  https://github.com/fnichol/limitation/blob/master/limitation/LICENSE.txt

--- a/crates/vendor/limitation/src/lib.rs
+++ b/crates/vendor/limitation/src/lib.rs
@@ -1,0 +1,377 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A rate limiter using a fixed window counter for arbitrary keys, backed by Redis.
+//!
+//! # About
+//!
+//! This library provides a fixed window counter for arbitrary keys backed by a Redis instance. The
+//! period length and per-period maximum limit are configurable on setup. The communication with
+//! the backend is performing in a non-blocking, asynchronous fashion allowing the library to pair
+//! with other async frameworks such as Tokio, Actix, etc.
+//!
+//! *Note*: Currently pre-*async/await* Futures are used (that is Futures 0.1.x) but that may be
+//! upgraded in the near future as the Rust 1.39.0 release is near.
+//!
+//! # Usage
+//!
+//! Add `limitation` to your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! limitation = "0.1.1"
+//! ```
+//!
+//! ## Quick Example
+//!
+//! The primary type is the [`Limiter`] which uses a builder to construct itself. Once built, use
+//! the [`count`] method with a key representing a user, a session, an interaction, etc. Note that
+//! `count` is a Future and therefore has to be driving to completion with a runtime. For example,
+//! to run one count on a key of `"10.0.0.5"`:
+//!
+//! [`Limiter`]: struct.Limiter.html
+//! [`count`]: struct.Limiter.html#method.count
+//!
+//! ```no_run
+//! use limitation::Limiter;
+//! use futures::Future;
+//!
+//! // Build a Limiter with a default rate with a local running Redis instance
+//! let limiter = Limiter::build("redis://127.0.0.1/").finish()?;
+//! // The key to count and track
+//! let key = "10.0.0.5";
+//!
+//! // Start and run a Tokio runtime to drive the Future to completion
+//! tokio::run(
+//!     limiter
+//!         // Count returns a Status if the key is under the limit and an `Error::LimitExceeded`
+//!         // containing a Status if the limit has been exceeded
+//!         .count(key)
+//!         // This example deals with both limit exceeded and any Redis connection issues. In this
+//!         // case we'll print the error to the standard error stream to show the current limit
+//!         // status
+//!         .map_err(|err| eprintln!("err: {}", err))
+//!         // In this case we are under the limit and can print out the limit status to the
+//!         // standard output stream
+//!         .and_then(|status| {
+//!             println!("ok: {:?}", status);
+//!             Ok(())
+//!         }),
+//! );
+//! # Ok::<(), limitation::Error>(())
+//! ```
+//!
+//! ## The Limiter Builder
+//!
+//! The builder for the `Limiter` has 2 settings which can be customized to the use case:
+//!
+//! - [`limit`]: The high water mark for number of requests in the period. The default is `5000`.
+//! - [`period`]: A `Duration` for the period window. The default is 60 minutes.
+//!
+//! ```no_run
+//! use limitation::Limiter;
+//! use std::time::Duration;
+//!
+//! let limiter = Limiter::build("redis://127.0.0.1/")
+//!     .limit(5)
+//!     .period(Duration::from_secs(10))
+//!     .finish()?;
+//! # Ok::<(), limitation::Error>(())
+//! ```
+//!
+//! [`limit`]: struct.Builder.html#method.limit
+//! [`period`]: struct.Builder.html#method.period
+//!
+//! # Examples
+//!
+//! A simple example that uses this library can be found in [limitation-example].
+//!
+//! [limitation-example]: https://github.com/fnichol/limitation/tree/master/limitation-example
+//!
+//! # Related Projects and References
+//!
+//! The primary inspiration for the implementation was a blog post called [An alternative approach
+//! to building a simple API Rate limiter using NodeJS and Redis][blog-post] by [Atul
+//! R](https://twitter.com/masteratul94).
+//!
+//! Other research and references used for this library:
+//!
+//! - <https://nordicapis.com/everything-you-need-to-know-about-api-rate-limiting/>
+//! - <https://hechao.li/2018/06/25/Rate-Limiter-Part1/>
+//! - <https://www.figma.com/blog/an-alternative-approach-to-rate-limiting/>
+//! - <https://engagor.github.io/blog/2017/05/02/sliding-window-rate-limiter-redis/>
+//!
+//! [blog-post]: https://blog.atulr.com/rate-limiter/
+//!
+//! # Ideas and Future Work
+//!
+//! These are some ideas and potential future work for this project. If you're reading this then
+//! maybe you're curious or interesting in helping out? Great! Be sure to check out the
+//! [Contributing] section and dig in!
+//!
+//! - Investigate and offer alternative rate-limiting algorithms, notably a Sliding Window
+//! solution.
+//! - Add async Redis connection pooling with the `bb8` and `bb8-redis` crates to reduce
+//! connection establishment delays.
+//! - Add a `status` method on `Limiter` which returns they key's `Status` without counting a
+//! request.
+//! - Add `RedisServer` support in an integration testing suite, similar to the infrastructure in
+//! the [redis] crate.
+//!
+//! [Contributing]: https://github.com/fnichol/limitation/tree/master/limitation#contributing
+//! [redis]: https://github.com/mitsuhiko/redis-rs/blob/master/tests/support/mod.rs
+
+#![doc(html_root_url = "https://docs.rs/limitation/0.1.1")]
+#![deny(missing_docs)]
+
+use chrono::SubsecRound;
+use futures::Future;
+use redis::Client;
+use std::convert::TryInto;
+use std::error;
+use std::fmt;
+use std::ops::Add;
+use std::time::Duration;
+
+/// The default limit of requests in a period
+const DEFAULT_LIMIT: usize = 5000;
+/// The default length of the period in seconds
+const DEFAULT_PERIOD_SECS: u64 = 60 * 60;
+
+/// A rate limiter using a fixed window counter, backed by Redis.
+///
+/// The per-period limit and the period duration are customizable when building an instance.
+///
+/// The [`count`] method is the primary unit of interaction which requires a key representing a
+/// user, a session, an interaction, etc. This method returns a Future which needs a runtime to
+/// drive the task to completion asynchronously.
+///
+/// [`count`]: #method.count
+#[derive(Clone, Debug)]
+pub struct Limiter {
+    /// The Redis client
+    client: Client,
+    /// The per-period limit
+    limit: usize,
+    /// The period duration
+    period: Duration,
+}
+
+impl Limiter {
+    /// Returns a builder for a `Limiter`.
+    ///
+    /// The [`finish`] method will build the final `Limiter` and perform a **synchronous**
+    /// connection test to the Redis backend.
+    ///
+    /// [`finish`]: struct.Builder.html#method.finish
+    pub fn build(redis_url: &str) -> Builder {
+        Builder {
+            redis_url,
+            limit: DEFAULT_LIMIT,
+            period: Duration::from_secs(DEFAULT_PERIOD_SECS),
+        }
+    }
+
+    /// Counts a request on a key over a period and returns a [`Status`].
+    ///
+    /// The `Status` type gives the caller a current state snapshot for the given key. If the limit
+    /// is exceeded a `Error::LimitExceeded` will be returned which also contains a `Status`.
+    /// Critically, the `Status` contains a time when the next period begins and the limit will
+    /// reset. The time is a "unix timestamp" in UTC time.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `Err` if:
+    ///
+    /// - The limit has been exceeded in the current period
+    /// - A client error has occurred
+    /// - A time computation failed
+    ///
+    /// [`Status`]: struct.Status.html
+    pub fn count<K: Into<String>>(&self, key: K) -> impl Future<Item = Status, Error = Error> {
+        let limit = self.limit;
+
+        self.track(key).and_then(move |(count, reset_epoch_utc)| {
+            let status = build_status(count, limit, reset_epoch_utc);
+
+            if count > limit {
+                Err(Error::LimitExceeded(status))
+            } else {
+                Ok(status)
+            }
+        })
+    }
+
+    /// Tracks the given key in a period and returns the count and TTL for the key in seconds.
+    fn track<K: Into<String>>(&self, key: K) -> impl Future<Item = (usize, usize), Error = Error> {
+        let key = key.into();
+        let exipres = self.period.as_secs();
+
+        self.client
+            .get_async_connection()
+            .from_err()
+            .and_then(move |con| {
+                // The seed of this approach is outlined Atul R in a blog post about rate limiting
+                // using NodeJS and Redis. For more details, see
+                // https://blog.atulr.com/rate-limiter/
+                let mut pipe = redis::pipe();
+                pipe.atomic()
+                    .cmd("SET")
+                    .arg(&key)
+                    .arg(0)
+                    .arg("EX")
+                    .arg(exipres)
+                    .arg("NX")
+                    .ignore()
+                    .cmd("INCR")
+                    .arg(&key)
+                    .cmd("TTL")
+                    .arg(&key);
+
+                pipe.query_async(con)
+                    .from_err()
+                    .and_then(|(_, (count, ttl)): (_, (usize, u64))| {
+                        Ok((count, epoch_utc_plus(Duration::from_secs(ttl))?))
+                    })
+            })
+    }
+}
+
+/// A report for a given key containing the limit status.
+///
+/// The status contains the following information:
+///
+/// - [`limit`]: the maximum number of requests allowed in the current period
+/// - [`remaining`]: how many requests are left in the current period
+/// - [`reset_epoch_utc`]: a UNIX timestamp in UTC approximately when the next period will begin
+///
+/// [`limit`]: #method.limit
+/// [`remaining`]: #method.remaining
+/// [`reset_epoch_utc`]: #method.reset_epoch_utc
+#[derive(Clone, Debug)]
+pub struct Status {
+    limit: usize,
+    remaining: usize,
+    reset_epoch_utc: usize,
+}
+
+impl Status {
+    /// Returns the maximum number of requests permitted in the current period.
+    pub fn limit(&self) -> usize {
+        self.limit
+    }
+
+    /// Returns the number of requests remaining in the current period.
+    pub fn remaining(&self) -> usize {
+        self.remaining
+    }
+
+    /// Returns a UNIX timestamp in UTC approximately when the next period will begin.
+    pub fn reset_epoch_utc(&self) -> usize {
+        self.reset_epoch_utc
+    }
+}
+
+/// A builder for a [`Limiter`].
+///
+/// [`Limiter`]: struct.Limiter.html
+pub struct Builder<'a> {
+    redis_url: &'a str,
+    limit: usize,
+    period: Duration,
+}
+
+impl Builder<'_> {
+    /// Sets a new maximum limit for the Limiter.
+    pub fn limit(&mut self, limit: usize) -> &mut Self {
+        self.limit = limit;
+        self
+    }
+
+    /// Sets a new period duration for the Limiter.
+    pub fn period(&mut self, period: Duration) -> &mut Self {
+        self.period = period;
+        self
+    }
+
+    /// Finializes and returns a `Limiter`.
+    ///
+    /// Note that this method will connect to the Redis server to test its connection which is a
+    /// **synchronous** operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `Err` if the Redis client fails to be created or fails to connect.
+    pub fn finish(&self) -> Result<Limiter, Error> {
+        Ok(Limiter {
+            client: Client::open(self.redis_url)?,
+            limit: self.limit,
+            period: self.period,
+        })
+    }
+}
+
+/// Error type for this crate.
+#[derive(Debug)]
+pub enum Error {
+    /// The Redis client failed to connect or run a query.
+    Client(redis::RedisError),
+    /// The limit is exceeded for a key.
+    LimitExceeded(Status),
+    /// A time conversion failed.
+    Time(time::OutOfRangeError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Client(ref err) => write!(f, "client error ({})", err),
+            Error::LimitExceeded(ref status) => write!(f, "rate limit exceeded ({:?})", status),
+            Error::Time(ref err) => write!(f, "time conversion error ({})", err),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Error::Client(ref err) => err.source(),
+            Error::LimitExceeded(_) => None,
+            Error::Time(ref err) => err.source(),
+        }
+    }
+}
+
+impl From<redis::RedisError> for Error {
+    fn from(err: redis::RedisError) -> Self {
+        Error::Client(err)
+    }
+}
+
+impl From<time::OutOfRangeError> for Error {
+    fn from(err: time::OutOfRangeError) -> Self {
+        Error::Time(err)
+    }
+}
+
+/// Builds a `Status`.
+fn build_status(count: usize, limit: usize, reset_epoch_utc: usize) -> Status {
+    let remaining = if count >= limit { 0 } else { limit - count };
+
+    Status {
+        limit,
+        remaining,
+        reset_epoch_utc,
+    }
+}
+
+/// Calculates a timestamp for "now plus a duration".
+fn epoch_utc_plus(duration: Duration) -> Result<usize, time::OutOfRangeError> {
+    Ok(chrono::Utc::now()
+        .add(chrono::Duration::from_std(duration)?)
+        .round_subsecs(0)
+        .timestamp()
+        .try_into()
+        .unwrap_or(0))
+}

--- a/crates/vendor/limitation/tests/version-numbers.rs
+++ b/crates/vendor/limitation/tests/version-numbers.rs
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#[test]
+fn test_readme_deps() {
+    version_sync::assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+fn test_html_root_url() {
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
The limitation crate is four years old, stuck at 0.1.1. It looks unlikey to be updated by the maintainer.

Upgrades to chrono and other libraries have broken limitation, so we're likely now on the hook for maintaining this.