### PR TITLE
send favorite/comment counts with media file list endpoint

### DIFF
--- a/crates/service/web/storyteller_web/src/http_server/common_responses/media_file_social_meta_lite.rs
+++ b/crates/service/web/storyteller_web/src/http_server/common_responses/media_file_social_meta_lite.rs
@@ -1,0 +1,21 @@
+use tokens::tokens::media_files::MediaFileToken;
+
+
+/// Fields useful for enriching media file listings
+#[derive(Clone, Serialize)]
+pub struct MediaFileSocialMetaLight {
+    pub favorites_count: u64,
+    pub comments_count: u64,
+}
+
+impl MediaFileSocialMetaLight {
+    pub fn from_db_fields(
+        favorites_count: u64,
+        comments_count: u64,
+    ) -> Self {
+        Self {
+            favorites_count,
+            comments_count,
+        }
+    }
+}

--- a/crates/service/web/storyteller_web/src/http_server/common_responses/mod.rs
+++ b/crates/service/web/storyteller_web/src/http_server/common_responses/mod.rs
@@ -1,3 +1,4 @@
 pub mod pagination_cursors;
 pub mod pagination_page;
 pub mod user_details_lite;
+pub mod media_file_social_meta_lite;

--- a/crates/service/web/storyteller_web/src/http_server/endpoints/media_files/list_media_files.rs
+++ b/crates/service/web/storyteller_web/src/http_server/endpoints/media_files/list_media_files.rs
@@ -14,6 +14,7 @@ use enums::by_table::media_files::media_file_type::MediaFileType;
 use enums::common::visibility::Visibility;
 use mysql_queries::queries::media_files::list_media_files::{list_media_files, ListMediaFilesArgs, ViewAs};
 use tokens::tokens::media_files::MediaFileToken;
+use crate::http_server::common_responses::media_file_social_meta_lite::MediaFileSocialMetaLight;
 
 use crate::http_server::common_responses::pagination_cursors::PaginationCursors;
 use crate::http_server::common_responses::user_details_lite::UserDetailsLight;
@@ -51,6 +52,7 @@ pub struct MediaFileListItem {
   pub maybe_public_bucket_extension: Option<String>,
 
   pub maybe_creator: Option<UserDetailsLight>,
+  pub maybe_social_meta: Option<MediaFileSocialMetaLight>,
 
   pub creator_set_visibility: Visibility,
 
@@ -174,7 +176,7 @@ pub async fn list_media_files_handler(
 
   let results = results_page.records.into_iter()
       .map(|record| MediaFileListItem {
-        token: record.token,
+        token: record.token.clone(),
         origin_category: record.origin_category,
         origin_product_category: record.origin_product_category,
         maybe_origin_model_type: record.maybe_origin_model_type,
@@ -189,6 +191,10 @@ pub async fn list_media_files_handler(
           record.maybe_creator_display_name,
           record.maybe_creator_gravatar_hash,
         ),
+        maybe_social_meta: Option::from(MediaFileSocialMetaLight::from_db_fields(
+            record.favorite_count,
+            record.comment_count,
+        )),
         creator_set_visibility: record.creator_set_visibility,
         created_at: record.created_at,
         updated_at: record.updated_at,


### PR DESCRIPTION
The query seems to work okay. @echelon lmk if you think it's better to have these as top level fields instead.


@echelon Should we model the list endpoint assuming it could be a public call? since it might power a FE feed and the cursors are setup for an infinite scroll. it might be better to make a batch call for "user has favorited" that the FE can make in case it is being made for a signed in user and we could probably reuse for profile page tabs.