### PR TITLE
Add missing data in response

### DIFF
--- a/crates/lib/mysql_queries/src/queries/model_weights/get_weight.rs
+++ b/crates/lib/mysql_queries/src/queries/model_weights/get_weight.rs
@@ -14,7 +14,7 @@ use tokens::tokens::{model_weights::ModelWeightToken, users::UserToken};
 //  'weights_type: enums::by_table::model_weights::weights_types::WeightsType' use this to map
 // Retrieved Model Weight can be constrained to the fields that are needed
 
-pub struct RetrivedModelWeight {
+pub struct RetrievedModelWeight {
     pub token: ModelWeightToken,
     pub title: String,
     pub weights_type: WeightsType,
@@ -60,7 +60,7 @@ pub async fn get_weight_by_token(
     weight_token: &ModelWeightToken,
     can_see_deleted: bool,
     mysql_pool: &MySqlPool
-) -> AnyhowResult<Option<RetrivedModelWeight>> {
+) -> AnyhowResult<Option<RetrievedModelWeight>> {
     let mut connection = mysql_pool.acquire().await?;
     get_weights_by_token_with_connection(weight_token, can_see_deleted, &mut connection).await
 }
@@ -69,7 +69,7 @@ pub async fn get_weights_by_token_with_connection(
     weight_token: &ModelWeightToken,
     can_see_deleted: bool,
     mysql_connection: &mut PoolConnection<MySql>
-) -> AnyhowResult<Option<RetrivedModelWeight>> {
+) -> AnyhowResult<Option<RetrievedModelWeight>> {
     let maybe_result = if can_see_deleted {
         select_include_deleted(weight_token, mysql_connection).await
     } else {
@@ -90,7 +90,7 @@ pub async fn get_weights_by_token_with_connection(
     // unwrap the result
 
     Ok(
-        Some(RetrivedModelWeight {
+        Some(RetrievedModelWeight {
             token: record.token,
             title: record.title,
             weights_type: record.weights_type,

--- a/crates/service/job/inference_job/src/job/job_types/videofilter/rerender_a_video/download_model_file.rs
+++ b/crates/service/job/inference_job/src/job/job_types/videofilter/rerender_a_video/download_model_file.rs
@@ -7,7 +7,7 @@ use buckets::public::media_files::bucket_file_path::MediaFileBucketPath;
 use cloud_storage::bucket_client::BucketClient;
 use jobs_common::job_progress_reporter::job_progress_reporter::JobProgressReporter;
 use mysql_queries::queries::generic_inference::job::list_available_generic_inference_jobs::AvailableInferenceJob;
-use mysql_queries::queries::model_weights::get_weight::RetrivedModelWeight;
+use mysql_queries::queries::model_weights::get_weight::RetrievedModelWeight;
 
 use crate::job::job_loop::process_single_job_error::ProcessSingleJobError;
 use crate::util::maybe_download_file_from_bucket::{maybe_download_file_from_bucket, MaybeDownloadArgs};
@@ -18,7 +18,7 @@ pub struct ModelFile {
 }
 
 pub async fn download_model_file(
-    model_record: &Option<RetrivedModelWeight>,
+    model_record: &Option<RetrievedModelWeight>,
     public_bucket_client: &BucketClient,
     job_progress_reporter: &mut Box<dyn JobProgressReporter>,
     job: &AvailableInferenceJob,

--- a/crates/service/web/storyteller_web/src/http_server/endpoints/weights/get_weight.rs
+++ b/crates/service/web/storyteller_web/src/http_server/endpoints/weights/get_weight.rs
@@ -48,6 +48,7 @@ pub struct GetWeightResponse {
     
     version: i32,
     created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
 }
 
 #[derive(Deserialize,ToSchema)]
@@ -181,7 +182,8 @@ pub async fn get_weight_handler(
         maybe_cached_user_ratings_ratio: weight.maybe_cached_user_ratings_ratio,
         cached_user_ratings_last_updated_at: weight.cached_user_ratings_last_updated_at,
         version: weight.version,
-        created_at: weight.created_at
+        created_at: weight.created_at,
+        updated_at: weight.updated_at
     };
 
     let body = serde_json::to_string(&response)

--- a/crates/service/web/storyteller_web/src/http_server/endpoints/weights/list_weights_by_user.rs
+++ b/crates/service/web/storyteller_web/src/http_server/endpoints/weights/list_weights_by_user.rs
@@ -21,7 +21,7 @@ use crate::server_state::ServerState;
 pub struct Weight {
   weight_token: ModelWeightToken,
   title: String,
-  
+  weights_category: String,
   creator: UserDetailsLight,
   creator_set_visibility: Visibility,
 
@@ -153,6 +153,7 @@ pub async fn list_weights_by_user_handler(
     Weight {
       weight_token: weight.token,
       title: weight.title,
+      weights_category: weight.weights_category.to_string(),
       creator: UserDetailsLight::from_db_fields(
         &weight.creator_user_token,
         &weight.creator_username,


### PR DESCRIPTION
get weight endpoint to have updated_at (the list weight has but the single weight doesnt) profile weight list endpoint weights_category is missing from the response, i need it for rendering the cards by what type of weight it is.