### PR TITLE
color picker ux

### DIFF
--- a/frontend/realtime/src/components/features/ToolbarMain/ToolbarMain.tsx
+++ b/frontend/realtime/src/components/features/ToolbarMain/ToolbarMain.tsx
@@ -47,7 +47,7 @@ export const ToolbarMain = ({
           paperWrapperStyles,
           "glass",
           disabled &&
-          "pointer-events-none cursor-default bg-ui-border shadow-md",
+            "pointer-events-none cursor-default bg-ui-border shadow-md",
         )}
       >
         <div className="flex flex-col items-center gap-2">
@@ -154,23 +154,40 @@ export const ToolbarMain = ({
         <hr className="w-full border-t border-white/15" />
 
         <div className="flex flex-col items-center gap-2">
-          {buttonProps.PAINT.active ?
-            <ColorPicker color={paintColor.value} onChange={dispatchUiEvents.toolbarMain.setPaintColor} faIcon={faPaintbrush} borderStyle="" showBar={false} fillBg streamChanges />
-            :
+          <div className="flex flex-col items-center gap-2">
+            {buttonProps.PAINT.active ? (
+              <div className="relative">
+                <ColorPicker
+                  color={paintColor.value}
+                  onChange={dispatchUiEvents.toolbarMain.setPaintColor}
+                  faIcon={faPaintbrush}
+                  borderStyle="border-2  bg-primary/30 border-2 border-primary hover:bg-primary/30 text-white"
+                  showBar={false}
+                  staticIconColor="white"
+                  streamChanges
+                  defaultOpen={true}
+                  anchor="right"
+                  anchorGap={12}
+                  closeOnMouseLeave={true}
+                />
+                <div
+                  className="pointer-events-none absolute -bottom-1.5 -right-1.5 h-[18px] w-[18px] rounded-full border border-gray-400"
+                  style={{ backgroundColor: paintColor.value }}
+                />
+              </div>
+            ) : (
+              <ToolbarButton
+                icon={faPaintbrush}
+                buttonProps={buttonProps.PAINT}
+                tooltip="Paint Brush"
+              />
+            )}
             <ToolbarButton
-              icon={faPaintbrush}
-              buttonProps={{
-                style: { backgroundColor: paintColor.value },
-                ...buttonProps.PAINT
-              }}
-              tooltip="Paint Brush"
+              icon={faEraser}
+              buttonProps={buttonProps.ERASER}
+              tooltip="Eraser"
             />
-          }
-          <ToolbarButton
-            icon={faEraser}
-            buttonProps={buttonProps.ERASER}
-            tooltip="Eraser"
-          />
+          </div>
         </div>
 
         <hr className="w-full border-t border-white/15" />

--- a/frontend/realtime/src/components/ui/TextEditor/ColorPicker.tsx
+++ b/frontend/realtime/src/components/ui/TextEditor/ColorPicker.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, useState, useEffect } from "react";
 import { twMerge } from "tailwind-merge";
 import {
   faFont,
@@ -20,9 +20,12 @@ export const ColorPicker = ({
   borderStyle,
   showBar = true,
   anchor = "bottom",
+  anchorGap = 0,
   fillBg = false,
   staticIconColor,
-  streamChanges = false
+  streamChanges = false,
+  defaultOpen = false,
+  closeOnMouseLeave = false,
 }: {
   color: string;
   onChange: (newColor: string) => void;
@@ -30,10 +33,14 @@ export const ColorPicker = ({
   borderStyle?: string;
   showBar?: boolean;
   anchor?: "top" | "right" | "bottom" | "left";
+  anchorGap?: number;
   fillBg?: boolean;
-  staticIconColor?: string,
-  streamChanges?: boolean
+  staticIconColor?: string;
+  streamChanges?: boolean;
+  defaultOpen?: boolean;
+  closeOnMouseLeave?: boolean;
 }) => {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
   const [{ currColor, textInput }, setStates] = useState<{
     currColor: string;
     textInput: string;
@@ -42,16 +49,18 @@ export const ColorPicker = ({
     textInput: prevColor.substring(1),
   });
 
-  const handleSelectColor = (newColor: string) => {
-    if (streamChanges) {
-      onChange(newColor);
+  useEffect(() => {
+    setIsOpen(defaultOpen);
+  }, [defaultOpen]);
+
+  const handleMouseLeave = (close: () => void) => {
+    if (closeOnMouseLeave) {
+      onChange(currColor);
+      setIsOpen(false);
+      close();
     }
-    setStates({ currColor: newColor, textInput: newColor.substring(1) });
   };
-  const isHexColorCode = (color: string) => {
-    const hexColorRegex = /^(?:[0-9a-fA-F]{3}){1,2}$/;
-    return hexColorRegex.test(color);
-  };
+
   const handleTextInput = (e: ChangeEvent<HTMLInputElement>) => {
     if (isHexColorCode(e.target.value)) {
       setStates({
@@ -66,64 +75,100 @@ export const ColorPicker = ({
     }
   };
 
+  const isHexColorCode = (color: string) => {
+    const hexColorRegex = /^(?:[0-9a-fA-F]{3}){1,2}$/;
+    return hexColorRegex.test(color);
+  };
+
   return (
     <Popover className="relative">
-      <PopoverButton
-        className={twMerge(
-          "bg-ui-controls flex size-10 items-center gap-1 rounded-md p-2",
-          borderStyle,
-          showBar ? "flex-col" : "justify-center"
-        )}
-        style={fillBg ? { backgroundColor: prevColor } : {}}
-      >
-        <FontAwesomeIcon icon={faIcon} color={fillBg ? staticIconColor : prevColor} />
-        {showBar && (
-          <span className="h-1 w-full" style={{ backgroundColor: prevColor }} />
-        )}
-      </PopoverButton>
-      <PopoverPanel
-        anchor={anchor}
-        className={twMerge(
-          paperWrapperStyles,
-          "flex flex-col items-center gap-2 overflow-hidden",
-        )}
-      >
-        {({ close }) => {
-          return (
-            <>
-              <HexColorPicker color={currColor} onChange={handleSelectColor} />
-              <Input
-                style={{ width: "198px" }}
-                icon={faHashtag}
-                value={textInput}
-                onChange={handleTextInput}
+      {({ open, close }) => (
+        <>
+          <PopoverButton
+            className={twMerge(
+              "flex size-10 items-center gap-1 rounded-lg bg-ui-controls p-2",
+              borderStyle,
+              showBar ? "flex-col" : "justify-center",
+            )}
+            style={fillBg ? { backgroundColor: prevColor } : {}}
+            onMouseEnter={() => defaultOpen && setIsOpen(true)}
+          >
+            <FontAwesomeIcon
+              icon={faIcon}
+              color={staticIconColor ?? (fillBg ? undefined : prevColor)}
+            />
+            {showBar && (
+              <span
+                className="h-1 w-full"
+                style={{ backgroundColor: prevColor }}
               />
-              <div className="flex w-full justify-center gap-2">
-                <Button
-                  variant="secondary"
-                  onClick={() => {
+            )}
+          </PopoverButton>
+          {(open || isOpen) && (
+            <div onMouseLeave={() => handleMouseLeave(close)}>
+              <PopoverPanel
+                anchor={anchor}
+                className={twMerge(
+                  paperWrapperStyles,
+                  "flex flex-col items-center gap-2 overflow-hidden",
+                )}
+                style={
+                  {
+                    "--anchor-gap": `${anchorGap}px`,
+                  } as React.CSSProperties
+                }
+                static
+              >
+                <HexColorPicker
+                  className="overflow-hidden"
+                  color={currColor}
+                  onChange={(color) => {
                     setStates({
-                      currColor: prevColor,
-                      textInput: prevColor.substring(1),
+                      currColor: color,
+                      textInput: color.substring(1),
                     });
-                    close();
+                    if (streamChanges) {
+                      onChange(color);
+                    }
                   }}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  onClick={() => {
-                    onChange(currColor);
-                    close();
-                  }}
-                >
-                  OK
-                </Button>
-              </div>
-            </>
-          );
-        }}
-      </PopoverPanel>
-    </Popover >
+                />
+                <Input
+                  style={{ width: "198px" }}
+                  icon={faHashtag}
+                  value={textInput}
+                  onChange={handleTextInput}
+                />
+                {!closeOnMouseLeave && (
+                  <div className="flex w-full justify-center gap-2">
+                    <Button
+                      variant="secondary"
+                      onClick={() => {
+                        setStates({
+                          currColor: prevColor,
+                          textInput: prevColor.substring(1),
+                        });
+                        setIsOpen(false);
+                        close();
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        onChange(currColor);
+                        setIsOpen(false);
+                        close();
+                      }}
+                    >
+                      OK
+                    </Button>
+                  </div>
+                )}
+              </PopoverPanel>
+            </div>
+          )}
+        </>
+      )}
+    </Popover>
   );
 };

--- a/frontend/realtime/src/signals/uiEvents/toolbarMain/paintMode.ts
+++ b/frontend/realtime/src/signals/uiEvents/toolbarMain/paintMode.ts
@@ -1,11 +1,10 @@
-
 // Prompt settings
 // - Prompt text
 
 import { effect, signal } from "@preact/signals-react";
 
 // - Prompt strength
-export const DEFAULT_PAINT_COLOR: string = "#000000";
+export const DEFAULT_PAINT_COLOR: string = "#ff0000";
 export const paintColor = signal<string>(DEFAULT_PAINT_COLOR);
 export const setPaintColor = (data: string) => {
   paintColor.value = data;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8544977e-5d4c-4ad6-bfaa-a7bc500a3c83)

changes:
- active styling and circular preview
- if paint brush button is active, hovering over the button will open the color picker automatically and when mouse leaves the picker popover panel, it closes and confirms. Reduces multiple clicks for a better experience.