### PR TITLE
Fix 3D performance decay after generation

### DIFF
--- a/frontend/apps/editor3d/app/src/pages/PageEnigma/Editor/editor.ts
+++ b/frontend/apps/editor3d/app/src/pages/PageEnigma/Editor/editor.ts
@@ -753,8 +753,11 @@ class Editor {
     }
 
     // Store original renderer and camera state
-    const originalWidth = this.renderer.domElement.width;
-    const originalHeight = this.renderer.domElement.height;
+    const sizeVector = new THREE.Vector2();
+    this.renderer.getSize(sizeVector);
+
+    const originalWidth = sizeVector.x;
+    const originalHeight = sizeVector.y;
     const originalPixelRatio = this.renderer.getPixelRatio();
     const originalCameraAspect = this.camera.aspect;
     const originalRenderCameraAspect =


### PR DESCRIPTION
Use 3JS size api instead of direct domElement access (avoids implicit pixel density scaling)