### PR TITLE
image/video promptbox generation bug fixes

### DIFF
--- a/frontend/libs/components/promptbox/src/lib/ImagePromptRow.tsx
+++ b/frontend/libs/components/promptbox/src/lib/ImagePromptRow.tsx
@@ -420,11 +420,12 @@ export const ImagePromptRow = ({
                 <div className="flex items-center gap-2 opacity-90">
                   <FontAwesomeIcon icon={faImage} className="h-3.5 w-3.5" />
                   <span className="text-sm text-white font-medium flex items-center gap-1.5">
-                    Ending Frame
+                    Ending Frame{" "}
+                    <span className="text-white/60 text-xs">(optional)</span>
                   </span>
                 </div>
                 <span className="text-[13px] text-white/60">
-                  Optional end frame
+                  How the animation ends
                 </span>
               </div>
               <div className="flex gap-2 items-center">

--- a/frontend/libs/components/promptbox/src/lib/PromptBoxImage.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBoxImage.tsx
@@ -223,6 +223,16 @@ export const PromptBoxImage = ({
   };
 
   const handleEnqueue = async () => {
+    if (!prompt.trim()) {
+      console.warn("Cannot generate image: prompt is empty");
+      return;
+    }
+
+    if (!selectedModel) {
+      console.warn("Cannot generate image: no model selected");
+      return;
+    }
+
     setIsEnqueueing(true);
 
     gtagEvent("enqueue_image");


### PR DESCRIPTION
- make top image prompt row always show for video
- video promptbox pops a toast when reference image is empty
- description changes for ending frame section
- hid the add image button for video generation for now since that's almost always required