### PR TITLE
history stack no shrink and divider styling update

### DIFF
--- a/frontend/apps/editor3d/app/src/pages/PageEdit/HistoryStack.tsx
+++ b/frontend/apps/editor3d/app/src/pages/PageEdit/HistoryStack.tsx
@@ -174,7 +174,7 @@ export const HistoryStack = ({
                   <Button
                     key={image.mediaToken}
                     className={twMerge(
-                      "group relative aspect-square h-full w-full overflow-hidden rounded-lg border-2 bg-transparent p-0 hover:bg-transparent hover:opacity-80",
+                      "group relative aspect-square h-full w-full shrink-0 overflow-hidden rounded-lg border-2 bg-transparent p-0 hover:bg-transparent hover:opacity-80",
                       selectedImageToken === image.mediaToken &&
                         "border-primary hover:opacity-100",
                     )}

--- a/frontend/apps/editor3d/app/src/styles/base.css
+++ b/frontend/apps/editor3d/app/src/styles/base.css
@@ -92,7 +92,7 @@ body {
   --st-controls-rgb: 62 62 65;
   --st-controls-border: #464646;
   --st-fg: #ffffff;
-  --st-divider: #303030;
+  --st-divider: #424242;
   --st-color-scheme: dark;
   --st-gallery-vignette-alpha: 0.3;
   --st-photo-tint-rgb: 0 0 0;
@@ -110,7 +110,7 @@ body {
   --st-controls-rgb: 17 17 17;
   --st-controls-border: #242424;
   --st-fg: #ffffff;
-  --st-divider: #242424;
+  --st-divider: #303030;
   --st-color-scheme: dark;
   --st-photo-tint-rgb: 0 0 0;
   --st-photo-tint-alpha: 0;


### PR DESCRIPTION
- history stack now doesn't get squashed
- clearer divider color