### PR TITLE
text to image results now pass lightbox media id and modal resize bug fix

### DIFF
--- a/frontend/apps/editor3d/app/src/pages/PageImage/TextToImage.tsx
+++ b/frontend/apps/editor3d/app/src/pages/PageImage/TextToImage.tsx
@@ -21,6 +21,7 @@ import { useTextToImageStore } from "./TextToImageStore";
 import { animated, useSpring } from "@react-spring/web";
 import {
   galleryModalLightboxImage,
+  galleryModalLightboxMediaId,
   galleryModalLightboxVisible,
 } from "@storyteller/ui-gallery-modal";
 import { Badge } from "@storyteller/ui-badge";
@@ -140,16 +141,27 @@ const TextToImage = ({ imageMediaId, imageUrl }: TextToImageProps) => {
                             <button
                               key={img.media_token}
                               onClick={() => {
-                                galleryModalLightboxImage.value = {
+                                const lightboxItem = {
                                   id: img.media_token,
                                   label: batch.prompt || "Generated Image",
-                                  thumbnail:
-                                    img.maybe_thumbnail_template || img.cdn_url,
+                                  thumbnail: img.cdn_url,
                                   fullImage: img.cdn_url,
                                   createdAt: new Date(
                                     batch.createdAt,
                                   ).toISOString(),
+                                  mediaClass: "image" as const,
+                                  mediaTokens: batch.images.map(
+                                    (image) => image.media_token,
+                                  ),
+                                  imageUrls: batch.images.map(
+                                    (image) => image.cdn_url,
+                                  ),
+                                  thumbnailUrlTemplate:
+                                    img.maybe_thumbnail_template,
                                 };
+                                galleryModalLightboxMediaId.value =
+                                  lightboxItem.id;
+                                galleryModalLightboxImage.value = lightboxItem;
                                 galleryModalLightboxVisible.value = true;
                               }}
                               className="aspect-square w-full overflow-hidden rounded-lg"

--- a/frontend/libs/components/lightbox-modal/src/lib/lightbox-modal.tsx
+++ b/frontend/libs/components/lightbox-modal/src/lib/lightbox-modal.tsx
@@ -334,7 +334,7 @@ export function LightboxModal({
       <Modal
         isOpen={isOpen}
         onClose={onClose}
-        className="rounded-xl bg-ui-modal h-[75vh] w-[60vw] max-w-screen min-w-[35vw] min-h-[40vh] p-4"
+        className="rounded-xl bg-ui-modal h-[760px] w-[1000px] max-w-screen min-w-[1000px] min-h-[600px] p-4"
         draggable
         allowBackgroundInteraction={true}
         showClose={true}
@@ -450,7 +450,7 @@ export function LightboxModal({
           </div>
 
           {/* info + actions */}
-          <div className="flex h-full flex-col">
+          <div className="flex h-full flex-col col-span-1">
             <div className="flex-1 space-y-5 text-base-fg">
               {/* <div className="text-xl font-medium">
               {title || "Image Generation"}


### PR DESCRIPTION
- clicking from text to image page results now shows action buttons in lightbox
- resizing modal from sides or corners that are not bottom or right now doesn't move the modal once it reaches min size
- limited the min size of the lightbox modal so that the layout doesnt break