### PR TITLE
fix brief No items yet flash after username fetch resolves

### DIFF
--- a/frontend/libs/components/gallery-modal/src/lib/gallery-modal.tsx
+++ b/frontend/libs/components/gallery-modal/src/lib/gallery-modal.tsx
@@ -467,6 +467,7 @@ export const GalleryModal = React.memo(
         setUsernameError(false);
         const name = await getCachedUsername();
         if (name) {
+          setInitialLoading(true); // keep skeleton alive until refreshGallery takes over
           setUsername(name);
           // refreshGallery (triggered by username state change) handles initialLoading
         } else {


### PR DESCRIPTION
setInitialLoading(true) and setUsername(name) are batched together so React never produces a frame where username is set but initialLoading is still false, which would fall through to the No items yet branch before refreshGallery has a chance to set initialLoading(true) itself.