### PR TITLE
Fix video aspect ratio icon not updating on gallery recreate

### DIFF
--- a/frontend/libs/components/promptbox/src/lib/PromptBoxVideo.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBoxVideo.tsx
@@ -759,9 +759,8 @@ export const PromptBoxVideo = ({
   };
 
   const getCurrentAspectRatioIcon = (): SizeIconOption => {
-    const selectedLabel = aspectRatioList.find((item) => item.selected)?.label;
     const allOptions = selectedModel?.sizeOptions ?? DEFAULT_RESOLUTIONS;
-    const match = allOptions.find((o) => o.textLabel === selectedLabel);
+    const match = allOptions.find((o) => o.textLabel === aspectRatio);
     return match?.icon ?? SizeIconOption.Landscape;
   };
 


### PR DESCRIPTION
getCurrentAspectRatioIcon() was reading from aspectRatioList (useState), which is only updated on manual picker clicks, not external store writes. Reading aspectRatio from the store directly fixes the stale icon.