### PR TITLE
shift enter to generate by default, toggleable via settings panel in app

### DIFF
--- a/frontend/apps/artcraft-website/src/components/prompt-box/MentionTextarea.tsx
+++ b/frontend/apps/artcraft-website/src/components/prompt-box/MentionTextarea.tsx
@@ -587,7 +587,10 @@ export const MentionTextarea = forwardRef<HTMLDivElement, MentionTextareaProps>(
           }
         }
 
-        if (e.key === "Enter" && (e.shiftKey || e.metaKey)) {
+        // Default: plain Enter inserts a newline (instead of letting the
+        // contentEditable create a <div>). Shift/Cmd+Enter falls through to
+        // externalOnKeyDown so the host can submit.
+        if (e.key === "Enter" && !e.shiftKey && !e.metaKey) {
           e.preventDefault();
           document.execCommand("insertLineBreak");
           handleInput();

--- a/frontend/apps/artcraft-website/src/components/prompt-box/PromptBox.tsx
+++ b/frontend/apps/artcraft-website/src/components/prompt-box/PromptBox.tsx
@@ -291,7 +291,8 @@ export const PromptBox = forwardRef<HTMLDivElement, PromptBoxProps>(
           }
         }
 
-        if (e.key === "Enter" && !e.shiftKey) {
+        // Default: Enter inserts a newline; Shift+Enter submits.
+        if (e.key === "Enter" && e.shiftKey) {
           e.preventDefault();
           onSubmit();
         }
@@ -435,7 +436,8 @@ export const PromptBox = forwardRef<HTMLDivElement, PromptBoxProps>(
                     )}
                     colorMap={mentionColorMap}
                     onKeyDown={(e) => {
-                      if (e.key === "Enter" && !e.shiftKey && !e.metaKey) {
+                      // Default: Enter inserts a newline; Shift+Enter (or Cmd+Enter) submits.
+                      if (e.key === "Enter" && (e.shiftKey || e.metaKey)) {
                         e.preventDefault();
                         onSubmit();
                       }

--- a/frontend/libs/components/promptbox/src/lib/MentionTextarea.tsx
+++ b/frontend/libs/components/promptbox/src/lib/MentionTextarea.tsx
@@ -11,6 +11,7 @@ import { twMerge } from "tailwind-merge";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUser } from "@fortawesome/pro-solid-svg-icons";
 import { faVideo, faMusic } from "@fortawesome/pro-regular-svg-icons";
+import { useEnterToGenerateStore } from "./promptStore";
 
 export interface MentionItem {
   label: string;
@@ -324,6 +325,7 @@ export const MentionTextarea = forwardRef<HTMLDivElement, MentionTextareaProps>(
     const isInternalUpdate = useRef(false);
     const isComposing = useRef(false);
     const pendingCaret = useRef<number | null>(null);
+    const enterToGenerate = useEnterToGenerateStore((s) => s.enabled);
 
     const [mentionState, setMentionState] = useState<MentionState>({
       isOpen: false,
@@ -618,15 +620,22 @@ export const MentionTextarea = forwardRef<HTMLDivElement, MentionTextareaProps>(
           }
         }
 
-        // Shift+Enter (or Cmd+Enter on Mac): insert a newline instead of
-        // letting the contentEditable create a <div>
-        if (e.key === "Enter" && (e.shiftKey || e.metaKey)) {
-          e.preventDefault();
-          document.execCommand("insertLineBreak");
-          handleInput();
-          // Scroll caret into view (textarea does this automatically, contentEditable does not)
-          scrollCaretIntoView(editorRef.current!);
-          return;
+        // Insert a newline instead of letting the contentEditable create a <div>.
+        // When `enterToGenerate` is off (default), plain Enter inserts a newline
+        // and Shift/Cmd+Enter submits via externalOnKeyDown. When the user opts
+        // into Enter-to-generate, the modifier combo is what inserts the newline.
+        if (e.key === "Enter") {
+          const newlineCombo = enterToGenerate
+            ? e.shiftKey || e.metaKey
+            : !e.shiftKey && !e.metaKey;
+          if (newlineCombo) {
+            e.preventDefault();
+            document.execCommand("insertLineBreak");
+            handleInput();
+            // Scroll caret into view (textarea does this automatically, contentEditable does not)
+            scrollCaretIntoView(editorRef.current!);
+            return;
+          }
         }
 
         externalOnKeyDown?.(e);
@@ -638,6 +647,7 @@ export const MentionTextarea = forwardRef<HTMLDivElement, MentionTextareaProps>(
         handleSelect,
         externalOnKeyDown,
         handleInput,
+        enterToGenerate,
       ],
     );
 

--- a/frontend/libs/components/promptbox/src/lib/PromptBox2D.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBox2D.tsx
@@ -18,7 +18,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 
-import { Prompt2DStore, RefImage } from "./promptStore";
+import { Prompt2DStore, RefImage, useEnterToGenerateStore } from "./promptStore";
 import { ImageModel } from "@storyteller/model-list";
 import { ImagePromptRow, UploadImageFn } from "./ImagePromptRow";
 import { twMerge } from "tailwind-merge";
@@ -97,6 +97,7 @@ export const PromptBox2D = ({
 
   const referenceImages = usePrompt2DStore((s) => s.referenceImages);
   const setReferenceImages = usePrompt2DStore((s) => s.setReferenceImages);
+  const enterToGenerate = useEnterToGenerateStore((s) => s.enabled);
   const [showImagePrompts, setShowImagePrompts] = useState(false);
   const [aspectRatioList, setAspectRatioList] = useState<PopoverItem[]>([
     {
@@ -330,7 +331,9 @@ export const PromptBox2D = ({
     // Stop propagation of keyboard events to prevent them from reaching the canvas
     e.stopPropagation();
 
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key !== "Enter") return;
+    const isSubmitCombo = enterToGenerate ? !e.shiftKey : e.shiftKey;
+    if (isSubmitCombo) {
       e.preventDefault();
       handleGenerate();
     }

--- a/frontend/libs/components/promptbox/src/lib/PromptBox3D.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBox3D.tsx
@@ -44,7 +44,7 @@ import {
   EnqueueEditImageResolution,
   EnqueueEditImageRequest,
 } from "@storyteller/tauri-api";
-import { usePrompt3DStore } from "./promptStore";
+import { usePrompt3DStore, useEnterToGenerateStore } from "./promptStore";
 import { gtagEvent } from "@storyteller/google-analytics";
 import { CommonAspectRatio, ImageModel } from "@storyteller/model-list";
 import { GenerationProvider } from "@storyteller/api-enums";
@@ -129,6 +129,7 @@ export const PromptBox3D = ({
   };
   const referenceImages = usePrompt3DStore((s) => s.referenceImages);
   const setReferenceImages = usePrompt3DStore((s) => s.setReferenceImages);
+  const enterToGenerate = useEnterToGenerateStore((s) => s.enabled);
   const [showImagePrompts, setShowImagePrompts] = useState(false);
   const [aspectRatioList, setAspectRatioList] = useState<PopoverItem[]>([
     {
@@ -459,7 +460,9 @@ export const PromptBox3D = ({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     e.stopPropagation();
 
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key !== "Enter") return;
+    const isSubmitCombo = enterToGenerate ? !e.shiftKey : e.shiftKey;
+    if (isSubmitCombo) {
       e.preventDefault();
       handleEnqueue();
     }

--- a/frontend/libs/components/promptbox/src/lib/PromptBoxEdit.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBoxEdit.tsx
@@ -27,7 +27,7 @@ import { useEffect, useRef, useState } from "react";
 import { CommonAspectRatio, ImageModel } from "@storyteller/model-list";
 import { twMerge } from "tailwind-merge";
 import { ImagePromptRow, type UploadImageFn } from "./ImagePromptRow";
-import { RefImage, usePromptEditStore } from "./promptStore";
+import { RefImage, usePromptEditStore, useEnterToGenerateStore } from "./promptStore";
 import { toast } from "@storyteller/ui-toaster";
 import { GenerationProvider } from "@storyteller/api-enums";
 import { AspectRatioPicker } from "./common/AspectRatioPicker";
@@ -107,6 +107,7 @@ export const PromptBoxEdit = ({
   const setAspectRatio = usePromptEditStore((s) => s.setAspectRatio);
   const resolution = usePromptEditStore((s) => s.resolution);
   const setResolution = usePromptEditStore((s) => s.setResolution);
+  const enterToGenerate = useEnterToGenerateStore((s) => s.enabled);
 
   const [showImagePrompts, setShowImagePrompts] = useState(false);
 
@@ -237,7 +238,9 @@ export const PromptBoxEdit = ({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     e.stopPropagation();
 
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key !== "Enter") return;
+    const isSubmitCombo = enterToGenerate ? !e.shiftKey : e.shiftKey;
+    if (isSubmitCombo) {
       e.preventDefault();
       const busy = Boolean(isEnqueueing ?? internalEnqueueing);
       if (!prompt.trim() || isDisabled || busy) return;

--- a/frontend/libs/components/promptbox/src/lib/PromptBoxImage.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBoxImage.tsx
@@ -21,7 +21,7 @@ import {
 } from "@fortawesome/pro-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { CommonAspectRatio, ImageModel } from "@storyteller/model-list";
-import { usePromptImageStore, RefImage } from "./promptStore";
+import { usePromptImageStore, RefImage, useEnterToGenerateStore } from "./promptStore";
 import { gtagEvent } from "@storyteller/google-analytics";
 import { twMerge } from "tailwind-merge";
 import { ImagePromptRow } from "./ImagePromptRow";
@@ -116,6 +116,7 @@ export const PromptBoxImage = ({
 
   const referenceImages = usePromptImageStore((s) => s.referenceImages);
   const setReferenceImages = usePromptImageStore((s) => s.setReferenceImages);
+  const enterToGenerate = useEnterToGenerateStore((s) => s.enabled);
   const [uploadingImages, _setUploadingImages] = useState<
     { id: string; file: File }[]
   >([]);
@@ -395,7 +396,9 @@ export const PromptBoxImage = ({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key !== "Enter") return;
+    const isSubmitCombo = enterToGenerate ? !e.shiftKey : e.shiftKey;
+    if (isSubmitCombo) {
       e.preventDefault();
       handleEnqueue();
     }

--- a/frontend/libs/components/promptbox/src/lib/PromptBoxVideo.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBoxVideo.tsx
@@ -31,6 +31,7 @@ import {
   VideoInputMode,
   useCharactersStore,
   StoredCharacter,
+  useEnterToGenerateStore,
 } from "./promptStore";
 import { gtagEvent } from "@storyteller/google-analytics";
 import { ImagePromptRow } from "./ImagePromptRow";
@@ -136,6 +137,7 @@ export const PromptBoxVideo = ({
   const setInputMode = usePromptVideoStore((s) => s.setInputMode);
   const generationCount = usePromptVideoStore((s) => s.generationCount);
   const setGenerationCount = usePromptVideoStore((s) => s.setGenerationCount);
+  const enterToGenerate = useEnterToGenerateStore((s) => s.enabled);
   const [isEnqueueing, setIsEnqueueing] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -862,7 +864,9 @@ export const PromptBoxVideo = ({
       }
     }
 
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key !== "Enter") return;
+    const isSubmitCombo = enterToGenerate ? !e.shiftKey : e.shiftKey;
+    if (isSubmitCombo) {
       e.preventDefault();
 
       if (selectedModel?.requiresImage && referenceImages.length === 0) {
@@ -986,7 +990,11 @@ export const PromptBoxVideo = ({
                   }
                   className="promptbox-scrollbar text-md relative mb-2 min-h-[2.5em] w-full resize-y overflow-y-auto rounded bg-transparent pb-2 pr-2 pt-1 text-base-fg"
                   onKeyDown={(e) => {
-                    if (e.key === "Enter" && !e.shiftKey) {
+                    if (e.key !== "Enter") return;
+                    const isSubmitCombo = enterToGenerate
+                      ? !e.shiftKey
+                      : e.shiftKey;
+                    if (isSubmitCombo) {
                       e.preventDefault();
                       if (
                         selectedModel?.requiresImage &&

--- a/frontend/libs/components/promptbox/src/lib/promptStore.ts
+++ b/frontend/libs/components/promptbox/src/lib/promptStore.ts
@@ -207,6 +207,48 @@ export const usePromptEditStore = create<PromptEditStore>()((set) => ({
   setResolution: (resolution) => set({ resolution }),
 }));
 
+// ----- Enter-to-Generate Preference Store -----
+// Controls how the Enter key behaves inside prompt boxes.
+//   false (default): Enter inserts a newline; Shift+Enter submits.
+//   true:            Enter submits; Shift+Enter inserts a newline.
+// Persisted to localStorage so the choice survives reloads.
+const ENTER_TO_GENERATE_STORAGE_KEY = "artcraft_enter_to_generate";
+
+const readEnterToGenerate = (): boolean => {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(ENTER_TO_GENERATE_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+};
+
+const writeEnterToGenerate = (enabled: boolean) => {
+  if (typeof window === "undefined") return;
+  try {
+    if (enabled) {
+      window.localStorage.setItem(ENTER_TO_GENERATE_STORAGE_KEY, "true");
+    } else {
+      window.localStorage.removeItem(ENTER_TO_GENERATE_STORAGE_KEY);
+    }
+  } catch {
+    // ignore storage failures
+  }
+};
+
+interface EnterToGenerateStore {
+  enabled: boolean;
+  setEnabled: (enabled: boolean) => void;
+}
+
+export const useEnterToGenerateStore = create<EnterToGenerateStore>()((set) => ({
+  enabled: readEnterToGenerate(),
+  setEnabled: (enabled) => {
+    writeEnterToGenerate(enabled);
+    set({ enabled });
+  },
+}));
+
 // ----- Characters Store -----
 export interface StoredCharacter {
   character_token: string;

--- a/frontend/libs/components/settings-modal/src/lib/panes/MiscSettingsPane.tsx
+++ b/frontend/libs/components/settings-modal/src/lib/panes/MiscSettingsPane.tsx
@@ -9,16 +9,21 @@ import {
 import { PreferenceName, UpdateAppPreferences } from "@storyteller/tauri-api";
 import { open } from "@tauri-apps/plugin-dialog";
 import { Label } from "@storyteller/ui-label";
+import { Switch } from "@storyteller/ui-switch";
 import { DownloadDirectoryReveal } from "@storyteller/tauri-api";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFolder, faMagnifyingGlass, faRotateLeft } from "@fortawesome/pro-solid-svg-icons";
+import { useEnterToGenerateStore } from "@storyteller/ui-promptbox";
 
-interface MiscSettingsPaneProps {}
+interface MiscSettingsPaneProps { }
 
 export const MiscSettingsPane = (args: MiscSettingsPaneProps) => {
   const [preferences, setPreferences] = useState<
     AppPreferencesPayload | undefined
   >(undefined);
+
+  const enterToGenerate = useEnterToGenerateStore((s) => s.enabled);
+  const setEnterToGenerate = useEnterToGenerateStore((s) => s.setEnabled);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -103,6 +108,17 @@ export const MiscSettingsPane = (args: MiscSettingsPaneProps) => {
           <FontAwesomeIcon icon={faMagnifyingGlass} />
           Show Directory
         </Button>
+      </div>
+      <div className="flex flex-col gap-2 pt-3">
+        <div className="flex flex-col gap-0.5">
+          <Label htmlFor="enter-to-generate">Enter to generate</Label>
+          <p className="text-xs opacity-70">
+            When on, pressing Enter submits the prompt and Shift+Enter adds a
+            new line. When off (default), Enter adds a new line and Shift+Enter
+            submits.
+          </p>
+        </div>
+        <Switch enabled={enterToGenerate} setEnabled={setEnterToGenerate} />
       </div>
     </div>
   );


### PR DESCRIPTION
- Pressing **Enter** in any prompt box now adds a new line instead of submitting - fixes complaints about accidental generations
- **Shift+Enter** is the new submit shortcut
- Desktop app gets an "Enter to generate" toggle in Settings → General (off by default) for users who prefer the old behavior
- Applies to all prompt boxes in the Artcraft desktop app and the website