### PR TITLE
app: fix aspect ratio picker losing label after model switch

### DIFF
--- a/frontend/libs/components/promptbox/src/lib/PromptBox3D.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBox3D.tsx
@@ -181,22 +181,6 @@ export const PromptBox3D = ({
     if (mapped) onAspectRatioSelect(mapped);
   };
 
-  // When the user switches to a model whose `aspectRatios` doesn't
-  // include the currently-picked `commonAspectRatio`, the picker's
-  // selected item disappears (PopoverMenu's toggle mode finds no match
-  // and renders no label). Reset to the new model's default so the
-  // trigger always shows a valid label.
-  useEffect(() => {
-    if (!selectedImageModel?.supportsNewAspectRatio()) return;
-    if (commonAspectRatio === undefined) return;
-    const supported = selectedImageModel.aspectRatios ?? [];
-    if (supported.includes(commonAspectRatio)) return;
-    const def = selectedImageModel.defaultAspectRatio;
-    if (!def) return;
-    handleCommonAspectRatioSelect(def);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedImageModel]);
-
   useEffect(() => {
     if (textareaRef.current && !isExpanded) {
       textareaRef.current.style.height = "auto";

--- a/frontend/libs/components/promptbox/src/lib/common/AspectRatioPicker.tsx
+++ b/frontend/libs/components/promptbox/src/lib/common/AspectRatioPicker.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { CommonAspectRatio } from "@storyteller/model-list";
 import { PopoverItem, PopoverMenu } from "@storyteller/ui-popover";
 import { Tooltip } from "@storyteller/ui-tooltip";
@@ -29,6 +30,18 @@ export const AspectRatioPicker = ({
 }: AspectRatioPickerProps) => {
   const useAspectRatio =
     currentAspectRatio ?? model.defaultAspectRatio ?? undefined;
+
+  // If the stored ratio isn't supported by the current model (e.g. user picked
+  // SquareHd on Imagen then switched to Flux Pro 1.1), reset to the model's
+  // default. Otherwise PopoverMenu's toggle mode finds no selected item and
+  // renders just the icon with no label.
+  useEffect(() => {
+    if (currentAspectRatio === undefined) return;
+    if (model.aspectRatios?.includes(currentAspectRatio)) return;
+    const def = model.defaultAspectRatio;
+    if (!def) return;
+    handleCommonAspectRatioSelect(def);
+  }, [model, currentAspectRatio, handleCommonAspectRatioSelect]);
 
   const isAutoRatio =
     useAspectRatio === CommonAspectRatio.Auto ||


### PR DESCRIPTION
When the stored `commonAspectRatio` (e.g. `SquareHd`) isn't in the newly-selected model's `aspectRatios`, `PopoverMenu` toggle mode found no selected item and collapsed the trigger to icon-only.

Reset to `model.defaultAspectRatio` from inside `AspectRatioPicker` so the fix applies to all three callers (image/edit/3D). Drops the duplicate workaround from `PromptBox3D`.