### PR TITLE
pagescene AssetMenu: fix featured Sets/Creatures never loading

### DIFF
--- a/frontend/libs/components/pagescene/src/lib/comps/AssetMenu/hooks/useFeaturedObjects.tsx
+++ b/frontend/libs/components/pagescene/src/lib/comps/AssetMenu/hooks/useFeaturedObjects.tsx
@@ -87,6 +87,12 @@ export const useFeaturedObjects = (props: useFeaturedObjectsProps) => {
   }, [nextPageCursor, props, editor]);
 
   useEffect(() => {
+    // Wait for the editor instance before claiming first-fetch ownership.
+    // Otherwise the IN_PROGRESS flip below would burn the slot on a no-op
+    // call (fetchFeaturedObjects bails at !editor), and the subsequent
+    // re-run after editor becomes available would see IN_PROGRESS and
+    // skip the actual fetch forever. See PR #1492 regression.
+    if (!editor) return;
     if (
       (firstFetch.current === FetchStatus.READY ||
         firstFetch.current === FetchStatus.ERROR) &&
@@ -95,7 +101,7 @@ export const useFeaturedObjects = (props: useFeaturedObjectsProps) => {
       firstFetch.current = FetchStatus.IN_PROGRESS;
       fetchFeaturedObjects();
     }
-  }, [fetchFeaturedObjects]);
+  }, [editor, fetchFeaturedObjects]);
 
   return {
     featuredObjects,


### PR DESCRIPTION
## Summary

- Regression from PR #1492. After the refactor, `useFeaturedObjects` auto-fetch effect was racing the `EngineContext` editor instance: on AssetModal's first mount `editor` is `null`, the effect synchronously flipped `firstFetch.current` to `IN_PROGRESS` and then called `fetchFeaturedObjects()` which immediately bailed at `if (!editor) return`. When the editor became available the effect re-fired (editor is in the `useCallback` deps), but the `IN_PROGRESS` guard then blocked it — so **the network request never fired** for any featured category.
- Visible only on Sets and Creatures tabs because Characters/Objects/Memes are merged with local demo arrays in `assetTabs` and looked populated despite the same fetch breakage.
- Fix: gate the auto-fetch effect on `editor` (early-return when null, add `editor` to deps) so `IN_PROGRESS` isn't burned on the no-op call.

## Test plan

- [ ] Open `/edit-3d` in artcraft-webapp with DevTools Network panel + "Disable cache" on.
- [ ] Open the AssetModal — confirm exactly 5 GETs to `/v1/media_files/list_featured` (one each for `character`, `object`, `location`, `creature`, `image_plane`).
- [ ] Switch to Sets and Creatures tabs — items render.
- [ ] Drag a Set into the 3D scene — loads via `addObject` (LOCATION maps to `AssetType.OBJECT` in `responseMapping`).
- [ ] Tauri smoke: open the 3D page in the desktop app, AssetModal Sets/Creatures tabs populate.
- [ ] `nx typecheck @storyteller/ui-pagescene` (no new errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)