### PR TITLE
3d splash screen and demo output overlay changes

### DIFF
--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/demo-output-overlay.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/demo-output-overlay.tsx
@@ -3,7 +3,9 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faCompress,
   faExpand,
+  faImage,
   faWandMagicSparkles,
+  faXmark,
 } from "@fortawesome/pro-solid-svg-icons";
 import { MediaFilesApi, PromptsApi } from "@storyteller/api";
 import { addCorsParam, PLACEHOLDER_IMAGES } from "@storyteller/common";
@@ -47,6 +49,7 @@ export function DemoOutputOverlay({ outputToken }: DemoOutputOverlayProps) {
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isHidden, setIsHidden] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -108,10 +111,25 @@ export function DemoOutputOverlay({ outputToken }: DemoOutputOverlayProps) {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [isExpanded]);
 
+  if (isHidden) {
+    return <ShowOutputPill onClick={() => setIsHidden(false)} />;
+  }
+
+  // The X button steps down one level: expanded → PIP, PIP → hidden.
+  // Lets users escape full-screen without losing the corner card.
+  const handleStepDown = () => {
+    if (isExpanded) {
+      setIsExpanded(false);
+      return;
+    }
+    setIsHidden(true);
+  };
+
   const body = (
     <Card
       isExpanded={isExpanded}
       onToggleExpanded={() => setIsExpanded((v) => !v)}
+      onHide={handleStepDown}
       promptText={promptText}
     >
       {loading ? (
@@ -143,15 +161,30 @@ export function DemoOutputOverlay({ outputToken }: DemoOutputOverlayProps) {
   }
 
   return (
-    <div className="pointer-events-none absolute right-4 top-4 z-30 w-[30%] min-w-[260px] max-w-lg animate-in fade-in slide-in-from-right-8 duration-500">
+    <div className="pointer-events-none absolute right-2 top-2 z-30 w-[30%] min-w-[260px] max-w-lg animate-in fade-in slide-in-from-right-8 duration-500">
       {body}
     </div>
+  );
+}
+
+function ShowOutputPill({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Show rendered output"
+      className="pointer-events-auto absolute right-2 top-2 z-30 flex items-center gap-2 rounded-xl border border-ui-controls-border bg-ui-controls px-3 py-1.5 text-sm font-medium text-base-fg shadow-xl transition-colors duration-150 hover:bg-ui-controls/80 animate-in fade-in slide-in-from-right-4"
+    >
+      <FontAwesomeIcon icon={faImage} className="h-3 w-3 text-primary" />
+      Show output
+    </button>
   );
 }
 
 interface CardProps {
   isExpanded: boolean;
   onToggleExpanded: () => void;
+  onHide: () => void;
   promptText: string | null;
   children: React.ReactNode;
 }
@@ -159,31 +192,61 @@ interface CardProps {
 function Card({
   isExpanded,
   onToggleExpanded,
+  onHide,
   promptText,
   children,
 }: CardProps) {
   return (
-    <div className="pointer-events-auto overflow-hidden rounded-xl border border-white/10 bg-black/50 shadow-2xl ring-1 ring-blue-500/20 backdrop-blur-lg">
-      <div className="flex items-center justify-between gap-3 border-b border-white/10 bg-gradient-to-r from-blue-500/10 via-transparent to-transparent px-3 py-2">
+    <div className="glass pointer-events-auto overflow-hidden rounded-xl shadow-xl border-2 border-primary">
+      <div className="flex items-center justify-between gap-3 border-b border-ui-controls-border/60 px-3 py-2">
         <div className="flex min-w-0 items-center gap-2">
           <FontAwesomeIcon
             icon={faWandMagicSparkles}
-            className="h-3 w-3 shrink-0 text-blue-300"
+            className="h-3 w-3 shrink-0 text-primary"
           />
           <div className="min-w-0 leading-tight">
-            <div className="text-xs font-semibold uppercase tracking-wider text-white">
+            <div className="text-xs font-semibold uppercase tracking-wider text-base-fg">
               Rendered Output
             </div>
-            <div className="truncate text-[10px] text-white/50">
+            <div className="truncate text-[10px] text-base-fg/50">
               Generated from this scene
             </div>
           </div>
         </div>
         <button
           type="button"
-          onClick={onToggleExpanded}
+          onClick={onHide}
+          aria-label={
+            isExpanded ? "Collapse to picture-in-picture" : "Hide rendered output"
+          }
+          className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-base-fg/60 transition-colors hover:bg-ui-controls hover:text-base-fg"
+        >
+          <FontAwesomeIcon icon={faXmark} className="h-4 w-4" />
+        </button>
+      </div>
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label={isExpanded ? "Collapse output view" : "Expand output view"}
+        onClick={onToggleExpanded}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggleExpanded();
+          }
+        }}
+        className={`relative aspect-video w-full bg-black/40 ${isExpanded ? "cursor-zoom-out" : "cursor-zoom-in"
+          }`}
+      >
+        {children}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleExpanded();
+          }}
           aria-label={isExpanded ? "Collapse output view" : "Expand output view"}
-          className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-white/60 transition hover:bg-white/10 hover:text-white"
+          className="absolute bottom-2 right-2 flex h-7 w-7 items-center justify-center rounded-md border border-white/10 bg-black/60 text-white/80 shadow-lg backdrop-blur-md transition-colors duration-150 hover:bg-black/80 hover:text-white"
         >
           <FontAwesomeIcon
             icon={isExpanded ? faCompress : faExpand}
@@ -191,16 +254,16 @@ function Card({
           />
         </button>
       </div>
-      <div className="relative aspect-video w-full bg-black/60">{children}</div>
       {promptText && (
         <div
-          className="border-t border-white/10 px-3 py-2 text-[11px] leading-snug text-white/70"
+          className="border-t border-ui-controls-border/60 px-3 py-2 text-[11px] leading-[15px] text-base-fg/70"
           title={promptText}
           style={{
             display: "-webkit-box",
             WebkitLineClamp: 2,
             WebkitBoxOrient: "vertical",
             overflow: "hidden",
+            maxHeight: "47px",
           }}
         >
           {promptText}
@@ -231,7 +294,8 @@ function OverlayMediaView({ media }: { media: OverlayMedia }) {
     <img
       src={src}
       alt="Rendered output"
-      className="h-full w-full object-contain"
+      draggable={false}
+      className="h-full w-full select-none object-contain"
       onError={(e) => {
         (e.currentTarget as HTMLImageElement).src = PLACEHOLDER_IMAGES.DEFAULT;
       }}

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/pagescene.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/pagescene.tsx
@@ -19,6 +19,12 @@ import { useSignupCta } from "../../components/signup-cta-modal";
 import { DemoOutputOverlay } from "./demo-output-overlay";
 import { useSceneCacheStore } from "./scene-cache-store";
 import { useWebAppPageSceneAdapter } from "./web-adapter";
+import {
+  SceneSplashModal,
+  useSceneSplashAutoOpen,
+  useSceneSplashLibSync,
+  useSceneSplashStore,
+} from "./splash";
 
 // Stage3D fills its parent box; this wrapper is that box. It clamps
 // the editor to the SidebarInset area and feeds the lib its rect:
@@ -73,6 +79,10 @@ function PageSceneEditor() {
     usePageSceneStore.getState().setCurrentUserToken(user?.user_token);
   }, [user?.user_token]);
 
+  useSceneSplashAutoOpen(sceneToken);
+  useSceneSplashLibSync();
+  const openSceneSplash = useSceneSplashStore((s) => s.open);
+
   const navigateToImageTo3D = useCallback(() => {
     navigate("/create-image");
   }, [navigate]);
@@ -112,6 +122,7 @@ function PageSceneEditor() {
     navigateToImageTo3D,
     getViewportSize,
     promptSignup: openSignupCta,
+    onRequestNewSceneSelector: openSceneSplash,
   });
 
   // Editor state survives navigating to other webapp pages: read the
@@ -158,6 +169,7 @@ function PageSceneEditor() {
       <GalleryModal mode="view" />
       <GalleryDragComponent />
       {demoOutputToken && <DemoOutputOverlay outputToken={demoOutputToken} />}
+      <SceneSplashModal currentSceneToken={sceneToken} />
     </div>
   );
 }

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/SceneSplashCard.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/SceneSplashCard.tsx
@@ -1,0 +1,85 @@
+// One reusable card for the edit-3D splash. The blank-scene variant
+// renders a dashed plus tile; the example variant renders a gradient
+// thumbnail with a "Preview" pill. Sharing one component keeps the
+// hover/border/typography treatment consistent across the grid.
+
+import { twMerge } from "tailwind-merge";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlus } from "@fortawesome/pro-solid-svg-icons";
+
+interface BlankCardProps {
+  variant: "blank";
+  title: string;
+  description: string;
+  onClick: () => void;
+}
+
+interface ExampleCardProps {
+  variant: "example";
+  title: string;
+  description: string;
+  accentClass: string;
+  onClick: () => void;
+}
+
+type SceneSplashCardProps = BlankCardProps | ExampleCardProps;
+
+const SHELL_CLASS =
+  "group flex flex-col overflow-hidden rounded-xl border bg-white/[0.03] text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60";
+
+export function SceneSplashCard(props: SceneSplashCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={props.onClick}
+      className={twMerge(
+        SHELL_CLASS,
+        props.variant === "blank"
+          ? "border-dashed border-white/15 hover:border-white/40 hover:bg-white/[0.05]"
+          : "border-white/10 hover:border-white/25 hover:bg-white/[0.05]",
+      )}
+    >
+      <CardThumbnail {...props} />
+      <CardCaption title={props.title} description={props.description} />
+    </button>
+  );
+}
+
+function CardThumbnail(props: SceneSplashCardProps) {
+  if (props.variant === "blank") {
+    return (
+      <div className="flex aspect-video items-center justify-center bg-white/[0.02]">
+        <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white/5 text-white/55 transition-colors group-hover:bg-primary/15 group-hover:text-primary">
+          <FontAwesomeIcon icon={faPlus} className="text-sm" />
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div
+      className={twMerge(
+        "relative aspect-video bg-gradient-to-br",
+        props.accentClass,
+      )}
+    >
+      <span className="absolute top-2 left-2 rounded-full bg-black/55 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-white/75 backdrop-blur-sm">
+        Preview
+      </span>
+    </div>
+  );
+}
+
+function CardCaption({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5 px-3 py-2.5">
+      <span className="text-sm font-medium text-white">{title}</span>
+      <span className="text-xs text-white/55">{description}</span>
+    </div>
+  );
+}

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/SceneSplashModal.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/SceneSplashModal.tsx
@@ -1,0 +1,72 @@
+// Edit-3D splash modal. Mirrors the design language of
+// SignupCtaModal (bg-[#161618], border-white/10, off-center primary
+// glow, font-display heading) so the editor's onboarding modal feels
+// like the rest of the webapp, not a one-off.
+
+import { Modal } from "@storyteller/ui-modal";
+import { useSceneSplashStore } from "./scene-splash-store";
+import { useSceneSplashActions } from "./useSceneSplashActions";
+import { SceneSplashCard } from "./SceneSplashCard";
+import { EXAMPLE_SCENES } from "./example-scenes";
+
+export function SceneSplashModal({
+  currentSceneToken,
+}: {
+  currentSceneToken?: string;
+}) {
+  const isOpen = useSceneSplashStore((s) => s.isOpen);
+  const close = useSceneSplashStore((s) => s.close);
+  const { pickBlank, pickExample } = useSceneSplashActions(currentSceneToken);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={close}
+      className="rounded-2xl w-full max-w-4xl overflow-hidden border border-white/10 bg-[#161618] p-0 shadow-[0_20px_60px_-15px_rgba(0,0,0,0.6)]"
+      childPadding={false}
+      backdropClassName="bg-black/80"
+      closeOnOutsideClick
+      showClose
+      accessibleTitle="Start a new scene"
+    >
+      <div className="relative overflow-hidden">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -top-24 -right-16 h-64 w-64 rounded-full bg-primary/25 blur-[80px]"
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/15 to-transparent"
+        />
+
+        <div className="relative px-8 pt-10 pb-8 sm:px-10 sm:pt-12 sm:pb-10">
+          <h2 className="font-display text-3xl font-semibold tracking-tight text-white sm:text-[34px] sm:leading-[1.1]">
+            Start a new <span className="text-primary">scene</span>.
+          </h2>
+          <p className="mt-3 max-w-md text-[15px] leading-relaxed text-white/55">
+            Open a blank stage or pick an example to get oriented.
+          </p>
+
+          <div className="mt-7 grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <SceneSplashCard
+              variant="blank"
+              title="Blank scene"
+              description="Empty stage, your camera"
+              onClick={pickBlank}
+            />
+            {EXAMPLE_SCENES.map((scene) => (
+              <SceneSplashCard
+                key={scene.id}
+                variant="example"
+                title={scene.title}
+                description={scene.description}
+                accentClass={scene.accentClass}
+                onClick={() => pickExample(scene)}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/example-scenes.ts
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/example-scenes.ts
@@ -1,0 +1,47 @@
+// Example-scene data for the edit-3D splash. Each card opens
+// `/edit-3d/${sceneToken}?output=${outputToken}` so the editor mounts
+// the scene and the demo-output overlay renders the AI-generated still
+// next to it. Real per-scene tokens land later; for now every entry
+// points at the same demo pair so the feature is exercised end-to-end.
+
+export interface ExampleScene {
+  id: string;
+  title: string;
+  description: string;
+  // Tailwind gradient class fragment used by the card's thumbnail. Kept
+  // as a class string (not a CSS color) so JIT picks it up at build time.
+  accentClass: string;
+  sceneToken: string;
+  outputToken: string;
+}
+
+// TODO: swap each entry to its own scene/output tokens once they ship.
+const PLACEHOLDER_SCENE_TOKEN = "m_tz8vm3vw3xsk5z5qvpq1y9cczdn2vp";
+const PLACEHOLDER_OUTPUT_TOKEN = "m_90b2hbzdbpm98gqfx08x53wpwsa1ew";
+
+export const EXAMPLE_SCENES: readonly ExampleScene[] = [
+  {
+    id: "cyberpunk-alley",
+    title: "Cyberpunk Alley",
+    description: "Neon-lit street, ground fog",
+    accentClass: "from-fuchsia-500/30 to-cyan-400/20",
+    sceneToken: PLACEHOLDER_SCENE_TOKEN,
+    outputToken: PLACEHOLDER_OUTPUT_TOKEN,
+  },
+  {
+    id: "mountain-vista",
+    title: "Mountain Vista",
+    description: "Golden-hour ridgeline",
+    accentClass: "from-amber-400/30 to-rose-400/20",
+    sceneToken: PLACEHOLDER_SCENE_TOKEN,
+    outputToken: PLACEHOLDER_OUTPUT_TOKEN,
+  },
+  {
+    id: "mecha-workshop",
+    title: "Mecha Workshop",
+    description: "Industrial bay with rigs",
+    accentClass: "from-sky-400/25 to-indigo-500/25",
+    sceneToken: PLACEHOLDER_SCENE_TOKEN,
+    outputToken: PLACEHOLDER_OUTPUT_TOKEN,
+  },
+];

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/index.ts
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/index.ts
@@ -1,0 +1,4 @@
+export { SceneSplashModal } from "./SceneSplashModal";
+export { useSceneSplashStore } from "./scene-splash-store";
+export { useSceneSplashAutoOpen } from "./useSceneSplashAutoOpen";
+export { useSceneSplashLibSync } from "./useSceneSplashLibSync";

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/scene-splash-store.ts
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/scene-splash-store.ts
@@ -1,0 +1,17 @@
+// Shared visibility store for the edit-3D splash. Lets the auto-open
+// hook, the adapter (File > New Scene), and the modal subscribe to one
+// source of truth without rebuilding the adapter on toggle.
+
+import { create } from "zustand";
+
+interface SceneSplashState {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export const useSceneSplashStore = create<SceneSplashState>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/useSceneSplashActions.ts
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/useSceneSplashActions.ts
@@ -1,0 +1,42 @@
+// Click handlers for the splash cards. Keeping these out of the modal
+// JSX means the modal stays presentation-only and the blank/example
+// flows share one place to update when real example scenes ship.
+
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { getActiveEditor } from "@storyteller/ui-pagescene";
+import { useSession } from "../../../lib/session";
+import { useSceneSplashStore } from "./scene-splash-store";
+import { markSplashSeen } from "./useSceneSplashAutoOpen";
+import type { ExampleScene } from "./example-scenes";
+
+const DEFAULT_TITLE = "Untitled New Scene";
+
+export function useSceneSplashActions(currentSceneToken: string | undefined) {
+  const close = useSceneSplashStore((s) => s.close);
+  const { loggedIn } = useSession();
+  const navigate = useNavigate();
+
+  const pickBlank = useCallback(async () => {
+    // Fresh visits (no token) already mount a blank stage, but calling
+    // newScene is harmless and gives the File > New Scene path a single
+    // code path with the "had a scene loaded" case.
+    await getActiveEditor()?.newScene(DEFAULT_TITLE);
+    if (currentSceneToken) navigate("/edit-3d");
+    if (loggedIn) markSplashSeen();
+    close();
+  }, [close, loggedIn, navigate, currentSceneToken]);
+
+  const pickExample = useCallback(
+    (scene: ExampleScene) => {
+      if (loggedIn) markSplashSeen();
+      close();
+      navigate(
+        `/edit-3d/${scene.sceneToken}?output=${scene.outputToken}`,
+      );
+    },
+    [close, loggedIn, navigate],
+  );
+
+  return { pickBlank, pickExample };
+}

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/useSceneSplashAutoOpen.ts
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/useSceneSplashAutoOpen.ts
@@ -1,0 +1,35 @@
+// Auto-opens the edit-3D splash on mount. Owns the localStorage gate so
+// pagescene.tsx never sees the key directly.
+//
+// Rules:
+//   - Never auto-open when the URL has a scene token (the user is
+//     visiting a specific scene; don't interrupt).
+//   - Anonymous visitors: open every time (no localStorage gate).
+//   - Signed-in users: open once, then suppress via SPLASH_SEEN_KEY.
+
+import { useEffect } from "react";
+import { useSession } from "../../../lib/session";
+import { useSceneSplashStore } from "./scene-splash-store";
+
+const SPLASH_SEEN_KEY = "edit_3d_splash_seen_v1";
+
+export function markSplashSeen(): void {
+  try {
+    localStorage.setItem(SPLASH_SEEN_KEY, "1");
+  } catch {
+    // Private mode / storage disabled — splash will simply reopen next
+    // visit, which is acceptable.
+  }
+}
+
+export function useSceneSplashAutoOpen(sceneToken: string | undefined): void {
+  const { loggedIn, authChecked } = useSession();
+  const open = useSceneSplashStore((s) => s.open);
+
+  useEffect(() => {
+    if (sceneToken) return;
+    if (!authChecked) return;
+    if (loggedIn && localStorage.getItem(SPLASH_SEEN_KEY)) return;
+    open();
+  }, [sceneToken, loggedIn, authChecked, open]);
+}

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/useSceneSplashLibSync.ts
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/useSceneSplashLibSync.ts
@@ -1,0 +1,23 @@
+// Mirrors the splash modal's visibility into the lib's PageSceneStore
+// (`hostOverlayVisible`). The lib uses that flag to suppress in-editor
+// affordances that would otherwise bleed through or behind the modal —
+// e.g. Controls3D's empty-scene "Click + to add your first asset!"
+// bouncing hint.
+//
+// Lives alongside the splash so the contract between webapp host and
+// lib stays in one place.
+
+import { useEffect } from "react";
+import { usePageSceneStore } from "@storyteller/ui-pagescene";
+import { useSceneSplashStore } from "./scene-splash-store";
+
+export function useSceneSplashLibSync(): void {
+  const isOpen = useSceneSplashStore((s) => s.isOpen);
+
+  useEffect(() => {
+    usePageSceneStore.getState().setHostOverlayVisible(isOpen);
+    return () => {
+      usePageSceneStore.getState().setHostOverlayVisible(false);
+    };
+  }, [isOpen]);
+}

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/web-adapter.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/web-adapter.tsx
@@ -127,12 +127,22 @@ export interface WebAppPageSceneAdapterOptions {
   // Open the host's signup CTA modal. Called from inside the lib when an
   // anonymous visitor clicks Save / Generate / Upload / My Library.
   promptSignup: (reason?: string) => void;
+  // Open the host's splash modal. Called from the lib's File > New Scene
+  // menu item; replaces the lib's inline confirm dialog.
+  onRequestNewSceneSelector: () => void;
 }
 
 export const useWebAppPageSceneAdapter = (
   options: WebAppPageSceneAdapterOptions,
 ): PageSceneAdapter => {
-  const { userToken, initialSceneToken, navigateToImageTo3D, getViewportSize, promptSignup } = options;
+  const {
+    userToken,
+    initialSceneToken,
+    navigateToImageTo3D,
+    getViewportSize,
+    promptSignup,
+    onRequestNewSceneSelector,
+  } = options;
 
   return useMemo<PageSceneAdapter>(
     () => ({
@@ -309,6 +319,8 @@ export const useWebAppPageSceneAdapter = (
 
       promptSignup,
 
+      onRequestNewSceneSelector,
+
       // Powers the lib's "Reset to original" menu item. The cache has
       // the server's snapshot we seeded on first load; pipe it back
       // through `Editor.applyJson` (which clears undo history and
@@ -340,6 +352,13 @@ export const useWebAppPageSceneAdapter = (
 
       initialSceneToken,
     }),
-    [userToken, initialSceneToken, navigateToImageTo3D, getViewportSize, promptSignup],
+    [
+      userToken,
+      initialSceneToken,
+      navigateToImageTo3D,
+      getViewportSize,
+      promptSignup,
+      onRequestNewSceneSelector,
+    ],
   );
 };

--- a/frontend/libs/components/button-dropdown/src/lib/button-dropdown.tsx
+++ b/frontend/libs/components/button-dropdown/src/lib/button-dropdown.tsx
@@ -109,7 +109,7 @@ export const ButtonDropdown = ({
               {options.map((option, index) => (
                 <Fragment key={index}>
                   {option.divider && (
-                    <div className="my-1.5 border-t border-ui-divider" />
+                    <div className="my-1.5 border-t border-white/5" />
                   )}
                   <Menu.Item>
                     {({ active }) => (

--- a/frontend/libs/components/pagescene/src/lib/PageSceneStore.ts
+++ b/frontend/libs/components/pagescene/src/lib/PageSceneStore.ts
@@ -186,6 +186,12 @@ interface PageSceneState {
   // Current logged-in user (read from host auth signal). Used for
   // ownership permission checks in ControlsTopButtons.
   currentUserToken: string | undefined;
+  // Host-owned full-screen overlay (e.g. webapp's splash modal) is
+  // open. Lib components use this to suppress in-editor affordances
+  // that would otherwise bleed visually through or behind the modal
+  // (the empty-scene "Click + to add" bouncing hint, etc.). The host
+  // toggles this via setHostOverlayVisible from its own modal store.
+  hostOverlayVisible: boolean;
 
   // canvas DOM refs (set by canvas components on mount; consumed by
   // the engine + hooks)
@@ -273,6 +279,7 @@ interface PageSceneState {
   // and authentication.userInfo into these).
   setSceneMeta: (meta: Partial<SceneMeta>) => void;
   setCurrentUserToken: (token: string | undefined) => void;
+  setHostOverlayVisible: (visible: boolean) => void;
 
   // canvas refs
   setSceneContainerEl: (el: HTMLDivElement | null) => void;
@@ -342,6 +349,7 @@ export const usePageSceneStore = create<PageSceneState>((set, get) => ({
     isInitializing: true,
   },
   currentUserToken: undefined,
+  hostOverlayVisible: false,
 
   sceneContainerEl: null,
   editorCanvasEl: null,
@@ -489,6 +497,7 @@ export const usePageSceneStore = create<PageSceneState>((set, get) => ({
   setSceneMeta: (meta) =>
     set((s) => ({ sceneMeta: { ...s.sceneMeta, ...meta } })),
   setCurrentUserToken: (token) => set({ currentUserToken: token }),
+  setHostOverlayVisible: (visible) => set({ hostOverlayVisible: visible }),
 
   setSceneContainerEl: (el) => set({ sceneContainerEl: el }),
   setEditorCanvasEl: (el) => set({ editorCanvasEl: el }),

--- a/frontend/libs/components/pagescene/src/lib/Stage3DBody.tsx
+++ b/frontend/libs/components/pagescene/src/lib/Stage3DBody.tsx
@@ -467,7 +467,7 @@ export const Stage3DBody = ({
               uploadImage={
                 editor
                   ? (((arg: Parameters<typeof editor.adapter.uploadImage>[0]) =>
-                      editor.adapter.uploadImage(arg)) as never)
+                    editor.adapter.uploadImage(arg)) as never)
                   : undefined
               }
               handleCameraSelect={handleCameraSelect}

--- a/frontend/libs/components/pagescene/src/lib/adapter.ts
+++ b/frontend/libs/components/pagescene/src/lib/adapter.ts
@@ -225,6 +225,12 @@ export interface PageSceneAdapter {
   // is always signed in. Webapp host wires this to its auth modal.
   promptSignup?(reason?: string): void;
 
+  // Open the host's New-Scene chooser (e.g. webapp's splash modal). When
+  // defined, the lib's File > New Scene item delegates here instead of
+  // showing its inline confirm dialog. Tauri host leaves it undefined and
+  // keeps the existing behavior.
+  onRequestNewSceneSelector?(): void;
+
   // Roll the current editor session back to the original scene the
   // host loaded. Called when the user confirms the destructive Reset
   // modal in the File menu. Implementations typically pull the

--- a/frontend/libs/components/pagescene/src/lib/comps/Controls3D/Controls3D.tsx
+++ b/frontend/libs/components/pagescene/src/lib/comps/Controls3D/Controls3D.tsx
@@ -4,6 +4,7 @@ import { useSignals } from "@preact/signals-react/runtime";
 import {
   faArrowsRotate,
   faArrowsUpDownLeftRight,
+  faGlobe,
   faMagicWandSparkles,
   faPlus,
   faUpRightAndDownLeftFromCenter,
@@ -48,6 +49,7 @@ export const Controls3D = ({
     selectedMode,
     transformSpace,
     currentUserToken,
+    hostOverlayVisible,
   } = usePageSceneStore(
     useShallow((s) => ({
       assetModalVisible: s.assetModalVisible,
@@ -56,6 +58,7 @@ export const Controls3D = ({
       selectedMode: s.selectedMode,
       transformSpace: s.transformSpace,
       currentUserToken: s.currentUserToken,
+      hostOverlayVisible: s.hostOverlayVisible,
     })),
   );
   const [showEmptySceneTooltip, setShowEmptySceneTooltip] = useState(false);
@@ -74,7 +77,8 @@ export const Controls3D = ({
       !isAddAssetPopoverOpen &&
       !upload3DIsShowing &&
       !uploadImageIsShowing &&
-      !uploadSplatIsShowing;
+      !uploadSplatIsShowing &&
+      !hostOverlayVisible;
 
     setShowEmptySceneTooltip(isSceneEmpty);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -86,6 +90,7 @@ export const Controls3D = ({
     upload3DIsShowing,
     uploadImageIsShowing,
     uploadSplatIsShowing,
+    hostOverlayVisible,
   ]);
 
   const handleModeChange = (value: string) => {
@@ -163,9 +168,9 @@ export const Controls3D = ({
 
   return (
     <>
-      <div className="flex justify-center">
-        <div className="glass rounded-b-xl p-1.5 pr-2 text-white shadow-md">
-          <div className="flex items-center justify-center gap-2.5">
+      <div className="flex justify-center pt-2">
+        <div className="glass rounded-2xl p-1.5 text-white shadow-xl">
+          <div className="flex items-center justify-center gap-1.5">
             <div className="flex items-center gap-1.5">
               <div className="relative">
                 {showEmptySceneTooltip && (
@@ -247,11 +252,10 @@ export const Controls3D = ({
                     ]}
                     onPanelAction={handleAddAssetAction}
                     showIconsInList
-                    buttonClassName={`h-9 w-9 rounded-[10px] text-lg ${
-                      showEmptySceneTooltip
-                        ? "bg-primary/90 hover:bg-primary/70"
-                        : "border-transparent bg-primary/90 hover:bg-primary/70"
-                    }`}
+                    buttonClassName={`h-9 w-9 rounded-xl text-lg ${showEmptySceneTooltip
+                      ? "bg-primary/90 hover:bg-primary/70"
+                      : "border-transparent bg-primary/90 hover:bg-primary/70"
+                      }`}
                     triggerIcon={
                       <FontAwesomeIcon icon={faPlus} className="text-xl" />
                     }
@@ -275,12 +279,13 @@ export const Controls3D = ({
               )}
             </div>
 
-            <span className="opacity-20">|</span>
+            <span className="opacity-10">|</span>
             <ButtonIconSelect
               options={modes}
               onOptionChange={handleModeChange}
               selectedOption={selectedMode}
             />
+            <span className="opacity-10">|</span>
             {selectedMode === "scale" ? (
               <Tooltip
                 content="Scale is always in local space"
@@ -289,8 +294,12 @@ export const Controls3D = ({
               >
                 <button
                   disabled
-                  className="h-9 rounded-[10px] px-2.5 text-[10px] font-semibold font-mono bg-white/15 uppercase tracking-wide opacity-40 cursor-not-allowed"
+                  className="flex min-w-[92px] cursor-not-allowed items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.04] px-3 py-1.5 text-sm font-medium text-base-fg opacity-40 transition-colors duration-150"
                 >
+                  <FontAwesomeIcon
+                    icon={faCube}
+                    className="h-3 w-3 text-base-fg/60"
+                  />
                   Local
                 </button>
               </Tooltip>
@@ -301,9 +310,13 @@ export const Controls3D = ({
                 delay={300}
               >
                 <button
-                  className="h-9 rounded-[10px] px-2.5 text-[10px] font-semibold font-mono bg-white/15 hover:bg-white/25 transition-colors uppercase tracking-wide"
+                  className="flex min-w-[92px] items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.04] px-3 py-1.5 text-sm font-medium text-base-fg transition-colors duration-150 hover:bg-white/[0.08]"
                   onClick={() => editor?.gizmo.toggleTransformSpace()}
                 >
+                  <FontAwesomeIcon
+                    icon={transformSpace === "world" ? faGlobe : faCube}
+                    className="h-3 w-3 text-base-fg/60"
+                  />
                   {transformSpace === "world" ? "World" : "Local"}
                 </button>
               </Tooltip>

--- a/frontend/libs/components/pagescene/src/lib/comps/ControlsTopButtons/ControlsTopButtons.tsx
+++ b/frontend/libs/components/pagescene/src/lib/comps/ControlsTopButtons/ControlsTopButtons.tsx
@@ -186,26 +186,37 @@ export const ControlsTopButtons = () => {
             {
               label: "New scene",
               description: "Ctrl+N",
-              dialogProps: {
-                title: "Create New Scene",
-                content: (
-                  <h4>
-                    Make sure you&apos;ve saved your scene. Unsaved changes
-                    will be lost. Continue?
-                  </h4>
-                ),
-                confirmButtonProps: {
-                  label: "Create new scene",
-                  onClick: async () => {
-                    handleResetScene();
-                    const defaultTitle = "Untitled New Scene";
-                    setSceneTitleInput(defaultTitle);
-                    await editor?.newScene(defaultTitle);
-                  },
-                },
-                closeButtonProps: { label: "Cancel" },
-                showClose: true,
-              },
+              // Hosts that own a New-Scene chooser (e.g. the webapp's
+              // splash modal) wire `onRequestNewSceneSelector` and take
+              // over confirm + action. Without it (Tauri), we fall back
+              // to the inline confirm dialog.
+              ...(editor?.adapter.onRequestNewSceneSelector
+                ? {
+                    onClick: () =>
+                      editor.adapter.onRequestNewSceneSelector?.(),
+                  }
+                : {
+                    dialogProps: {
+                      title: "Create New Scene",
+                      content: (
+                        <h4>
+                          Make sure you&apos;ve saved your scene. Unsaved
+                          changes will be lost. Continue?
+                        </h4>
+                      ),
+                      confirmButtonProps: {
+                        label: "Create new scene",
+                        onClick: async () => {
+                          handleResetScene();
+                          const defaultTitle = "Untitled New Scene";
+                          setSceneTitleInput(defaultTitle);
+                          await editor?.newScene(defaultTitle);
+                        },
+                      },
+                      closeButtonProps: { label: "Cancel" },
+                      showClose: true,
+                    },
+                  }),
             },
             {
               label: "Load my scene",


### PR DESCRIPTION
## Summary

Adds a Blender/Photoshop-style **splash modal** to `/edit-3d` so anonymous visitors and first-time signed-in users land on a clear choice - *Blank scene* or one of a few example scenes - instead of an empty viewport with no orientation. Also reworks the demo output overlay (now hide-able + click-to-expand) and gives the **Controls3D toolbar** a floating, design-coherent treatment that matches the rest of the editor's UI language.

## Highlights

- **Edit-3D splash**: auto-opens for anon (every visit) and first-time logged-in users (gated by `localStorage["edit_3d_splash_seen_v1"]`). Skips when the URL already has a scene token. Always re-triggerable from **File > New Scene**.
- **Demo output overlay**: click the image to expand, X steps down a level (expanded → PIP → hidden), `Show output` pill brings it back. Restyled to the editor's `glass` / `bg-ui-controls` palette.
- **Controls3D toolbar**: floating `rounded-2xl glass` pill, tightened spacing, lower-opacity dividers, World/Local button gets an icon + matched palette + fixed width so it doesn't shift on toggle.
- New `hostOverlayVisible` flag in the lib's `PageSceneStore` lets the webapp host suppress in-editor affordances (e.g. the bouncing "Click + to add" hint) while a modal is up.

## New files

```
frontend/apps/artcraft-webapp/src/pages/pagescene/splash/
├── index.ts                       barrel
├── scene-splash-store.ts          Zustand isOpen/open/close
├── example-scenes.ts              placeholder example data (sceneToken + outputToken)
├── useSceneSplashAutoOpen.ts      auto-open effect + localStorage gating
├── useSceneSplashActions.ts       pickBlank / pickExample handlers
├── useSceneSplashLibSync.ts       mirrors isOpen → lib's hostOverlayVisible
├── SceneSplashCard.tsx            reusable card (blank + example variants)
└── SceneSplashModal.tsx           presentation shell
```

Each file is single-responsibility; `pagescene.tsx` integration is three lines.

## Lib changes (`@storyteller/ui-pagescene`)

- **`adapter.ts`** — new optional `onRequestNewSceneSelector?()` on `PageSceneAdapter`. When defined (webapp), File > New Scene defers to the host's splash; when undefined (Tauri), the original confirm dialog stays.
- **`ControlsTopButtons.tsx`** — branches the New-scene menu item on the new adapter hook.
- **`PageSceneStore.ts`** — adds `hostOverlayVisible: boolean` + `setHostOverlayVisible(...)` so hosts can signal "full-screen overlay is up, hide editor affordances."
- **`Controls3D.tsx`** -
  - Outer wrapper now floats (`pt-2`) instead of being flush to the top.
  - Container `glass rounded-2xl p-1.5 shadow-xl`.
  - Inner gap `2.5 → 1.5`; both `|` dividers `opacity-20 → opacity-10`.
  - New divider added between Move/Rotate/Scale and World/Local.
  - **`+` add-asset button**: `rounded-lg` to match its `rounded-xl` parent.
  - **World/Local button**:
    - `faGlobe` / `faCube` icon prefix.
    - `border-white/10 bg-white/[0.04] hover:bg-white/[0.08]` (subtle "status" treatment, distinct from the selectable mode buttons).
    - `min-w-[92px] justify-center` so the toolbar doesn't shift on toggle.
    - Includes `!hostOverlayVisible` in the empty-scene tooltip gate.

## Webapp changes

- **`pagescene.tsx`** - wires `useSceneSplashAutoOpen`, `useSceneSplashLibSync`, passes `onRequestNewSceneSelector: openSceneSplash` to the adapter, renders `<SceneSplashModal />`.
- **`web-adapter.tsx`** - accepts + forwards `onRequestNewSceneSelector` (stable Zustand `open` action keeps the memo intact).
- **`demo-output-overlay.tsx`** -
  - New `isHidden` state; X button steps down (expanded → PIP → hidden).
  - `Show output` pill (top-right) when hidden; styled to mirror the top-left File-row buttons (`rounded-xl border-ui-controls-border bg-ui-controls`).
  - Expand control moved off the title bar to a darker, more legible `bg-black/60 backdrop-blur-md` overlay on the bottom-right of the image.
  - **Image is click-to-expand** (`cursor-zoom-in` / `cursor-zoom-out`); `draggable={false}` + `select-none` so drags/selections don't disrupt the click target; expand button uses `stopPropagation` to avoid double-firing.
  - Card body restyled to the `glass` / `bg-ui-controls-border` / `text-primary` palette.
  - Prompt caption gets `display: -webkit-box` + `WebkitLineClamp: 2` + `maxHeight: 47px` + `leading-[15px]` - belt-and-suspenders against the half-rendered third line that `line-clamp-2` alone was letting bleed through.

## Example scenes

All current entries in `example-scenes.ts` route to:

```
/edit-3d/m_tz8vm3vw3xsk5z5qvpq1y9cczdn2vp?output=m_90b2hbzdbpm98gqfx08x53wpwsa1ew
```

A `sceneToken` + `outputToken` shape is in place so per-scene tokens can be swapped in later by editing that file alone.