### PR TITLE
webapp: demo scene to support image AND video

### DIFF
--- a/frontend/apps/artcraft-webapp/src/main.tsx
+++ b/frontend/apps/artcraft-webapp/src/main.tsx
@@ -19,7 +19,7 @@ if (import.meta.env.DEV) {
       window.location.origin,
     );
     // NB: This is for Brandon to test with storyteller-web locally:
-    //StorytellerApiHostStore.getInstance().setDevelopment();
+    StorytellerApiHostStore.getInstance().setDevelopment();
   } catch (e) {
     console.warn("Failed to set dev API host override", e);
   }

--- a/frontend/apps/artcraft-webapp/src/main.tsx
+++ b/frontend/apps/artcraft-webapp/src/main.tsx
@@ -19,7 +19,7 @@ if (import.meta.env.DEV) {
       window.location.origin,
     );
     // NB: This is for Brandon to test with storyteller-web locally:
-    StorytellerApiHostStore.getInstance().setDevelopment();
+    //StorytellerApiHostStore.getInstance().setDevelopment();
   } catch (e) {
     console.warn("Failed to set dev API host override", e);
   }

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/demo-output-overlay.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/demo-output-overlay.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faCompress,
   faExpand,
   faImage,
+  faVideo,
   faWandMagicSparkles,
   faXmark,
 } from "@fortawesome/pro-solid-svg-icons";
@@ -11,96 +12,86 @@ import { MediaFilesApi, PromptsApi } from "@storyteller/api";
 import { addCorsParam, PLACEHOLDER_IMAGES } from "@storyteller/common";
 import { LoadingSpinner } from "@storyteller/ui-loading-spinner";
 import { Viewer3D } from "@storyteller/ui-viewer-3d";
-import { is3DModelUrl, isVideoUrl } from "../../components/lightbox/shared";
+import { is3DModelUrl } from "../../components/lightbox/shared";
 
 // Demo overlay rendered on top-right of the 3D editor when the URL carries
-// `?output=<media_token>` (alias: `?demo=<media_token>`). It resolves the
-// token to a media URL and renders the asset (image / video / 3D model)
-// in a 16:9 picture-in-picture card so the scene and its rendered output
-// can be shown side by side.
+// `?image=<media_token>` (or the legacy `?output=` / `?demo=` aliases) and
+// optionally `?video=<media_token>`. Each token is resolved independently
+// to a CDN URL and rendered in a 16:9 picture-in-picture card so the scene
+// and its rendered output can be shown side by side.
 //
-// UX details aimed at making the relationship obvious at a glance:
-//   - "Rendered Output" header with a wand-sparkles icon and a
-//     "Generated from this scene" subtitle so first-time viewers
-//     immediately understand the card is the AI render of the scene
-//     they're looking at.
-//   - Slide-in entrance animation draws the eye to the corner on load
-//     so the card isn't missed.
-//   - The title-bar expand button promotes the card to a centered
-//     larger view over the editor; clicking again (or the backdrop /
-//     Esc) collapses it back to the corner.
+// UX details:
+//   - "Rendered Output" header with a wand-sparkles icon and a "Generated
+//     from this scene" subtitle so first-time viewers immediately understand
+//     the card is the AI render of the scene they're looking at.
+//   - Slide-in entrance animation draws the eye to the corner on load.
+//   - The title-bar expand button promotes the card to a centered larger
+//     view over the editor; clicking again (or backdrop / Esc) collapses it.
+//   - When both an image and a video token are present, a small segmented
+//     toggle appears in the header. Video shows first (the toggle defaults
+//     to the video side); flipping the toggle swaps the rendered media
+//     *and* the prompt caption shown below it.
 //
-// The component is fully self-contained: it fetches its own media and
-// renders nothing while the token is unresolved or invalid.
+// The component is fully self-contained: it fetches both assets and renders
+// nothing while everything is unresolved or invalid.
 
 interface DemoOutputOverlayProps {
-  outputToken: string;
+  imageToken: string | null;
+  videoToken: string | null;
 }
 
-interface OverlayMedia {
+interface ResolvedAsset {
   url: string;
-  isVideo: boolean;
   is3D: boolean;
+  promptText: string | null;
 }
 
-export function DemoOutputOverlay({ outputToken }: DemoOutputOverlayProps) {
-  const [media, setMedia] = useState<OverlayMedia | null>(null);
-  const [promptText, setPromptText] = useState<string | null>(null);
+type View = "video" | "image";
+
+export function DemoOutputOverlay({
+  imageToken,
+  videoToken,
+}: DemoOutputOverlayProps) {
+  const [image, setImage] = useState<ResolvedAsset | null>(null);
+  const [video, setVideo] = useState<ResolvedAsset | null>(null);
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
   const [isHidden, setIsHidden] = useState(false);
+  // Video shows first when both tokens are provided. When only one token
+  // is present, the effective view derivation below pins to that side
+  // regardless of this value, so the initial pick only matters for the
+  // both-present case.
+  const [view, setView] = useState<View>(videoToken ? "video" : "image");
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setErrorMessage(null);
-    setMedia(null);
-    setPromptText(null);
+    setImage(null);
+    setVideo(null);
+    setView(videoToken ? "video" : "image");
 
     (async () => {
-      try {
-        const mediaResponse = await new MediaFilesApi().GetMediaFileByToken({
-          mediaFileToken: outputToken,
-        });
-        if (cancelled) return;
-
-        const file = mediaResponse?.data;
-        const url = file?.media_links?.cdn_url || null;
-        if (!mediaResponse?.success || !file || !url) {
-          setErrorMessage("Rendered output not found");
-          return;
-        }
-        setMedia({
-          url,
-          isVideo: isVideoUrl(url),
-          is3D: is3DModelUrl(url),
-        });
-
-        // The prompt fetch is best-effort and decorative; failures or a
-        // missing prompt_token should leave the card without a caption,
-        // not surface an error to the user.
-        if (file.maybe_prompt_token) {
-          const promptResponse = await new PromptsApi().GetPromptsByToken({
-            token: file.maybe_prompt_token,
-          });
-          if (cancelled) return;
-          const text = promptResponse?.success
-            ? promptResponse.data?.maybe_positive_prompt || null
-            : null;
-          setPromptText(text);
-        }
-      } catch {
-        if (!cancelled) setErrorMessage("Failed to load rendered output");
-      } finally {
-        if (!cancelled) setLoading(false);
+      const [imageResult, videoResult] = await Promise.all([
+        imageToken ? resolveAsset(imageToken) : Promise.resolve(null),
+        videoToken ? resolveAsset(videoToken) : Promise.resolve(null),
+      ]);
+      if (cancelled) return;
+      setImage(imageResult);
+      setVideo(videoResult);
+      const anyRequested = !!(imageToken || videoToken);
+      const anyResolved = !!(imageResult || videoResult);
+      if (anyRequested && !anyResolved) {
+        setErrorMessage("Rendered output not found");
       }
+      setLoading(false);
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [outputToken]);
+  }, [imageToken, videoToken]);
 
   useEffect(() => {
     if (!isExpanded) return;
@@ -110,6 +101,22 @@ export function DemoOutputOverlay({ outputToken }: DemoOutputOverlayProps) {
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [isExpanded]);
+
+  const hasImage = !!image;
+  const hasVideo = !!video;
+  // The selected `view` reflects user intent, but render against whichever
+  // side actually resolved — if a fetch fails, we silently fall back to
+  // the other side rather than showing an empty card with a dead toggle.
+  const effectiveView: View | null = useMemo(() => {
+    if (view === "video" && hasVideo) return "video";
+    if (view === "image" && hasImage) return "image";
+    if (hasVideo) return "video";
+    if (hasImage) return "image";
+    return null;
+  }, [view, hasImage, hasVideo]);
+  const activeAsset = effectiveView === "video" ? video : image;
+  const captionText = activeAsset?.promptText ?? null;
+  const showToggle = hasImage && hasVideo;
 
   if (isHidden) {
     return <ShowOutputPill onClick={() => setIsHidden(false)} />;
@@ -130,7 +137,13 @@ export function DemoOutputOverlay({ outputToken }: DemoOutputOverlayProps) {
       isExpanded={isExpanded}
       onToggleExpanded={() => setIsExpanded((v) => !v)}
       onHide={handleStepDown}
-      promptText={promptText}
+      captionText={captionText}
+      toggle={
+        showToggle && effectiveView ? (
+          <ViewToggle view={effectiveView} onChange={setView} />
+        ) : null
+      }
+      activeIsVideo={effectiveView === "video"}
     >
       {loading ? (
         <div className="absolute inset-0 flex items-center justify-center">
@@ -140,8 +153,8 @@ export function DemoOutputOverlay({ outputToken }: DemoOutputOverlayProps) {
         <div className="absolute inset-0 flex items-center justify-center px-3 text-center text-xs text-white/60">
           {errorMessage}
         </div>
-      ) : media ? (
-        <OverlayMediaView media={media} />
+      ) : activeAsset && effectiveView ? (
+        <OverlayMediaView asset={activeAsset} view={effectiveView} />
       ) : null}
     </Card>
   );
@@ -167,6 +180,36 @@ export function DemoOutputOverlay({ outputToken }: DemoOutputOverlayProps) {
   );
 }
 
+async function resolveAsset(token: string): Promise<ResolvedAsset | null> {
+  try {
+    const mediaResponse = await new MediaFilesApi().GetMediaFileByToken({
+      mediaFileToken: token,
+    });
+    const file = mediaResponse?.data;
+    const url = file?.media_links?.cdn_url;
+    if (!mediaResponse?.success || !file || !url) return null;
+    // Prompt fetch is best-effort and decorative; a missing or failed
+    // prompt token leaves the asset without a caption rather than
+    // failing the whole resolve.
+    let promptText: string | null = null;
+    if (file.maybe_prompt_token) {
+      try {
+        const promptResponse = await new PromptsApi().GetPromptsByToken({
+          token: file.maybe_prompt_token,
+        });
+        promptText = promptResponse?.success
+          ? promptResponse.data?.maybe_positive_prompt || null
+          : null;
+      } catch {
+        // leave promptText null
+      }
+    }
+    return { url, is3D: is3DModelUrl(url), promptText };
+  } catch {
+    return null;
+  }
+}
+
 function ShowOutputPill({ onClick }: { onClick: () => void }) {
   return (
     <button
@@ -181,11 +224,62 @@ function ShowOutputPill({ onClick }: { onClick: () => void }) {
   );
 }
 
+interface ViewToggleProps {
+  view: View;
+  onChange: (next: View) => void;
+}
+
+// Single-button sliding toggle. The whole pill is the click target —
+// clicking anywhere on it flips between video and image. A primary-
+// coloured indicator translates between the two icons to show which
+// side is currently active.
+function ViewToggle({ view, onChange }: ViewToggleProps) {
+  const next: View = view === "video" ? "image" : "video";
+  return (
+    <button
+      type="button"
+      aria-label={view === "video" ? "Switch to image" : "Switch to video"}
+      onClick={() => onChange(next)}
+      className="relative flex h-7 w-14 shrink-0 items-center rounded-full border border-ui-controls-border bg-black/30 p-0.5 transition-colors hover:bg-black/40"
+    >
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute top-0.5 bottom-0.5 left-0.5 w-[calc(50%-0.125rem)] rounded-full bg-primary shadow-sm transition-transform duration-200 ease-out"
+        style={{
+          transform: view === "image" ? "translateX(100%)" : "translateX(0%)",
+        }}
+      />
+      <ToggleIcon icon={faVideo} active={view === "video"} />
+      <ToggleIcon icon={faImage} active={view === "image"} />
+    </button>
+  );
+}
+
+interface ToggleIconProps {
+  icon: typeof faVideo;
+  active: boolean;
+}
+
+function ToggleIcon({ icon, active }: ToggleIconProps) {
+  return (
+    <span
+      className={
+        "relative z-10 flex h-full flex-1 items-center justify-center transition-colors " +
+        (active ? "text-white" : "text-base-fg/60")
+      }
+    >
+      <FontAwesomeIcon icon={icon} className="h-3 w-3" />
+    </span>
+  );
+}
+
 interface CardProps {
   isExpanded: boolean;
   onToggleExpanded: () => void;
   onHide: () => void;
-  promptText: string | null;
+  captionText: string | null;
+  toggle: React.ReactNode;
+  activeIsVideo: boolean;
   children: React.ReactNode;
 }
 
@@ -193,9 +287,22 @@ function Card({
   isExpanded,
   onToggleExpanded,
   onHide,
-  promptText,
+  captionText,
+  toggle,
+  activeIsVideo,
   children,
 }: CardProps) {
+  // When the video element is active, clicks on the native control bar
+  // must not bubble to the wrapper's expand handler — otherwise pressing
+  // play would also fullscreen the card. Suppress the wrapper handler
+  // for any click whose target lives inside a <video> element.
+  const handleMediaClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (activeIsVideo) {
+      const target = e.target as HTMLElement;
+      if (target.closest("video")) return;
+    }
+    onToggleExpanded();
+  };
   return (
     <div className="glass pointer-events-auto overflow-hidden rounded-xl shadow-xl border-2 border-primary">
       <div className="flex items-center justify-between gap-3 border-b border-ui-controls-border/60 px-3 py-2">
@@ -213,22 +320,27 @@ function Card({
             </div>
           </div>
         </div>
-        <button
-          type="button"
-          onClick={onHide}
-          aria-label={
-            isExpanded ? "Collapse to picture-in-picture" : "Hide rendered output"
-          }
-          className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-base-fg/60 transition-colors hover:bg-ui-controls hover:text-base-fg"
-        >
-          <FontAwesomeIcon icon={faXmark} className="h-4 w-4" />
-        </button>
+        <div className="flex items-center gap-2">
+          {toggle}
+          <button
+            type="button"
+            onClick={onHide}
+            aria-label={
+              isExpanded
+                ? "Collapse to picture-in-picture"
+                : "Hide rendered output"
+            }
+            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-base-fg/60 transition-colors hover:bg-ui-controls hover:text-base-fg"
+          >
+            <FontAwesomeIcon icon={faXmark} className="h-4 w-4" />
+          </button>
+        </div>
       </div>
       <div
         role="button"
         tabIndex={0}
         aria-label={isExpanded ? "Collapse output view" : "Expand output view"}
-        onClick={onToggleExpanded}
+        onClick={handleMediaClick}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
@@ -254,10 +366,10 @@ function Card({
           />
         </button>
       </div>
-      {promptText && (
+      {captionText && (
         <div
           className="border-t border-ui-controls-border/60 px-3 py-2 text-[11px] leading-[15px] text-base-fg/70"
-          title={promptText}
+          title={captionText}
           style={{
             display: "-webkit-box",
             WebkitLineClamp: 2,
@@ -266,19 +378,24 @@ function Card({
             maxHeight: "47px",
           }}
         >
-          {promptText}
+          {captionText}
         </div>
       )}
     </div>
   );
 }
 
-function OverlayMediaView({ media }: { media: OverlayMedia }) {
-  const src = addCorsParam(media.url) || media.url;
-  if (media.is3D) {
+interface OverlayMediaViewProps {
+  asset: ResolvedAsset;
+  view: View;
+}
+
+function OverlayMediaView({ asset, view }: OverlayMediaViewProps) {
+  const src = addCorsParam(asset.url) || asset.url;
+  if (asset.is3D) {
     return <Viewer3D modelUrl={src} isActive className="h-full w-full" />;
   }
-  if (media.isVideo) {
+  if (view === "video") {
     return (
       <video
         src={src}
@@ -287,6 +404,7 @@ function OverlayMediaView({ media }: { media: OverlayMedia }) {
         loop
         muted
         playsInline
+        controls
       />
     );
   }

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/other-scenes-overlay.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/other-scenes-overlay.tsx
@@ -14,8 +14,8 @@ import { EXAMPLE_SCENES } from "./splash/example-scenes";
 // pill that fades in below the model. Expanded: an inline panel that
 // grows upward with the same horizontal lane as the promptbox, listing
 // the curated example scenes minus the one the user is on. Clicking a
-// card navigates to that scene's demo URL — same shape as the splash
-// modal's pickExample.
+// card navigates to `/edit-3d/${sceneToken}?image=${outputToken}` —
+// same shape as the splash modal's pickExample.
 //
 // Rendering through the lib's slot (instead of as a separately
 // absolutely-positioned overlay) means the lib's `bottom-4` anchor
@@ -45,7 +45,7 @@ export function OtherScenesOverlay({
 
   const handlePick = (sceneToken: string, outputToken: string) => {
     setIsOpen(false);
-    navigate(`/edit-3d/${sceneToken}?output=${outputToken}`);
+    navigate(`/edit-3d/${sceneToken}?image=${outputToken}`);
   };
 
   return (

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/pagescene.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/pagescene.tsx
@@ -94,11 +94,20 @@ export default function PageScene() {
 function PageSceneEditor() {
   const { sceneToken } = useParams<{ sceneToken?: string }>();
   const [searchParams] = useSearchParams();
-  // `?output=<media_token>` (alias `?demo=`) flips the editor into demo
-  // mode: the named output media renders in a top-right picture-in-picture
-  // card alongside the live scene. Empty string is normalized to null.
-  const demoOutputToken =
-    searchParams.get("output") || searchParams.get("demo") || null;
+  // `?image=`, `?video=`, and the legacy `?output=` / `?demo=` aliases
+  // flip the editor into demo mode: the named media renders in a
+  // top-right picture-in-picture card alongside the live scene. `image`
+  // and `output`/`demo` are equivalent — they name the image side of
+  // the preview (the legacy aliases keep existing shared links working).
+  // `video` names a video token shown on the video side. When both sides
+  // are present, the card adds a toggle and starts on video.
+  const imageToken =
+    searchParams.get("image") ||
+    searchParams.get("output") ||
+    searchParams.get("demo") ||
+    null;
+  const videoToken = searchParams.get("video") || null;
+  const demoToken = imageToken || videoToken;
   const { user } = useSession();
   const navigate = useNavigate();
   const { setOpen } = useSidebar();
@@ -210,7 +219,7 @@ function PageSceneEditor() {
   // `?output=`, Stage3DBody's cold-sync handles the default letterbox by
   // reading the selected model's defaultAspectRatio (now 16:9 for the
   // InstructiveEdit-tagged models that populate STAGE_3D_PAGE_MODEL_LIST).
-  usePromptPrefillFromOutput(demoOutputToken);
+  usePromptPrefillFromOutput(imageToken);
 
   const navigateToImageTo3D = useCallback(() => {
     navigate("/create-image");
@@ -292,7 +301,7 @@ function PageSceneEditor() {
         promptboxAboveStackSlot={
           <OtherScenesOverlay
             currentSceneToken={sceneToken}
-            demoOutputToken={demoOutputToken}
+            demoOutputToken={demoToken}
           />
         }
       />
@@ -303,7 +312,9 @@ function PageSceneEditor() {
           adds. Both components portal themselves out of this wrapper. */}
       <GalleryModal mode="view" />
       <GalleryDragComponent />
-      {demoOutputToken && <DemoOutputOverlay outputToken={demoOutputToken} />}
+      {demoToken && (
+        <DemoOutputOverlay imageToken={imageToken} videoToken={videoToken} />
+      )}
       <SceneSplashModal currentSceneToken={sceneToken} />
     </div>
   );

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/example-scenes.ts
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/example-scenes.ts
@@ -1,5 +1,5 @@
 // Example-scene data for the edit-3D splash. Each card opens
-// `/edit-3d/${sceneToken}?output=${outputToken}` so the editor mounts
+// `/edit-3d/${sceneToken}?image=${outputToken}` so the editor mounts
 // the scene and the demo-output overlay renders the AI-generated still
 // next to it. Real per-scene tokens land later; for now every entry
 // points at the same demo pair so the feature is exercised end-to-end.

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/useSceneSplashActions.ts
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/splash/useSceneSplashActions.ts
@@ -32,7 +32,7 @@ export function useSceneSplashActions(currentSceneToken: string | undefined) {
       if (loggedIn) markSplashSeen();
       close();
       navigate(
-        `/edit-3d/${scene.sceneToken}?output=${scene.outputToken}`,
+        `/edit-3d/${scene.sceneToken}?image=${scene.outputToken}`,
       );
     },
     [close, loggedIn, navigate],

--- a/frontend/apps/artcraft-webapp/src/pages/pagescene/use-prompt-prefill-from-output.ts
+++ b/frontend/apps/artcraft-webapp/src/pages/pagescene/use-prompt-prefill-from-output.ts
@@ -1,8 +1,15 @@
 // Seeds the 3D editor's prompt-box state from the prompt that produced
-// the `?output=<media_token>` media. Used by the splash example flow and
-// by any lightbox/handoff that passes a rendered output through to the
-// 3D editor — opening "Lone Drifter" should drop the user into the same
+// the `?image=<media_token>` media (also accepts the legacy `?output=` /
+// `?demo=` aliases via the caller — see pagescene.tsx's `imageToken`
+// derivation). Used by the splash example flow and by any
+// lightbox/handoff that passes a rendered output through to the 3D
+// editor — opening "Lone Drifter" should drop the user into the same
 // prompt and model the example was generated with.
+//
+// The `?video=` token is intentionally *not* used here: when a demo
+// link carries both an image and a video, the user-facing intent is
+// "this image's prompt is what you'd want to start from"; the video
+// only drives the preview side of the overlay.
 //
 // Aspect ratio is intentionally not restored: Stage3DBody's cold-sync
 // applies the selected model's defaultAspectRatio (16:9 for the


### PR DESCRIPTION
PageScene's top-right preview card now first-classes video alongside images.

- **New query params**: `?image=<media_token>` and `?video=<media_token>`. `?image=` is an exact alias for the existing `?output=` (and `?demo=`), which keep working for legacy/shared links.
- **Toggle when both are set**: a small sliding pill in the card header switches between the video and image side. Video shows first. The whole pill is one click target - tap anywhere on it to flip.
- **Video gets native controls**: `<video autoplay muted loop playsInline controls>`. Wrapper click-to-expand suppresses clicks that land on the control bar so play/pause doesn't fullscreen the card.
- **Prompt caption follows the active side**: the line under the preview shows whichever asset (video or image) is currently displayed.
- **Promptbox 3D auto-prefill still uses the image's prompt** only. Video-only links skip prefill.
- Internal URL builders (splash modal `pickExample`, "See other demo scenes" overlay) now produce `?image=` URLs. External links with `?output=` continue to resolve via the parser fallback.