### PR TITLE
fix(webapp): prevent iOS caret loss in mobile prompt input

### DIFF
--- a/frontend/apps/artcraft-webapp/src/components/prompt-box/MentionTextarea.tsx
+++ b/frontend/apps/artcraft-webapp/src/components/prompt-box/MentionTextarea.tsx
@@ -406,6 +406,19 @@ export const MentionTextarea = forwardRef<HTMLDivElement, MentionTextareaProps>(
       const el = editorRef.current;
       if (!el) return;
 
+      // This effect re-runs whenever `buildHTML`'s identity changes (the parent
+      // recomputing `colorMap`/`mentionItems`), not only when `value` genuinely
+      // changes from outside. If the DOM already shows this exact text while the
+      // user is focused, skip the innerHTML rewrite entirely: reassigning
+      // innerHTML under a live caret detaches it on iOS Safari, which makes the
+      // cursor disappear mid-typing. A pending caret (mention insert) must still
+      // resync, and an unfocused editor is safe to recolor.
+      if (pendingCaret.current === null && document.activeElement === el) {
+        let domText = el.innerText;
+        if (domText.endsWith("\n")) domText = domText.slice(0, -1);
+        if (domText === value) return;
+      }
+
       const sel = window.getSelection();
       if (document.activeElement === el && sel && !sel.isCollapsed) return;
 

--- a/frontend/apps/artcraft-webapp/src/components/prompt-box/mobile/MobilePromptForm.tsx
+++ b/frontend/apps/artcraft-webapp/src/components/prompt-box/mobile/MobilePromptForm.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { type ReactNode, useMemo } from "react";
 import { GenerateButton } from "@storyteller/ui-button";
 import { MentionTextarea } from "../MentionTextarea";
 import { buildMentionColorMap } from "../mention-colors";
@@ -49,7 +49,12 @@ export function MobilePromptForm({
   countField,
 }: MobilePromptFormProps) {
   const { goToHistory } = useMobileCreateTabs();
-  const colorMap = buildMentionColorMap(mentionItems);
+  // Memoize so a new colorMap identity doesn't re-fire MentionTextarea's
+  // DOM-sync effect on every parent render (caret-loss source on iOS).
+  const colorMap = useMemo(
+    () => buildMentionColorMap(mentionItems),
+    [mentionItems],
+  );
 
   const handleCreate = () => {
     onSubmit();


### PR DESCRIPTION
MentionTextarea's DOM-sync effect rewrote innerHTML under the live caret whenever buildHTML's identity changed, detaching the cursor on iOS Safari mid-typing. Skip the rewrite when focused and the DOM already matches value, and memoize colorMap in MobilePromptForm to stop the per-render churn.