### PR TITLE
fix(ci): use pnpm instead of npm in artcraft publish workflows

### DIFF
--- a/.github/workflows/artcraft-macos-publish.yml
+++ b/.github/workflows/artcraft-macos-publish.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           node-version: lts/*
 
+      - name: setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -60,22 +65,8 @@ jobs:
           # Navigate to the frontend directory to install dependencies
           cd ./frontend
 
-          npm cache clean --force
-
-          echo "Installing all workspace dependencies..."
-          npm ci
-
-          echo "=== Version Information ==="
-          echo "Node version:"
-          node --version
-          echo "NPM version:"
-          npm --version
-
-          # Remove mismatched @nx packages and reinstall with correct versions
-          npm install --save-dev @nx/remix@21.1.1 @nx/js@21.1.1 @nx/react@21.1.1 @nx/vite@21.1.1 @nx/eslint@21.1.1
-
-          echo "=== Nx versions after adjustment ==="
-          npm list --depth=0 | grep nx
+          # The frontend is a pnpm workspace; npm cannot resolve "workspace:*" deps
+          pnpm install --frozen-lockfile
 
       - name: import Apple Developer Certificate
         if: matrix.platform == 'macos-latest-xlarge'

--- a/.github/workflows/artcraft-windows-publish.yml
+++ b/.github/workflows/artcraft-windows-publish.yml
@@ -43,27 +43,18 @@ jobs:
         with:
           node-version: lts/*
 
+      - name: setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
       - name: install frontend dependencies
         run: |
           # Navigate to the frontend directory to install dependencies
           cd ./frontend
 
-          npm cache clean --force
-
-          echo "Installing all workspace dependencies..."
-          npm ci
-
-          echo "=== Version Information ==="
-          echo "Node version:"
-          node --version
-          echo "NPM version:"
-          npm --version
-
-          # Remove mismatched @nx packages and reinstall with correct versions
-          npm install --save-dev @nx/remix@21.1.1 @nx/js@21.1.1 @nx/react@21.1.1 @nx/vite@21.1.1 @nx/eslint@21.1.1
-
-          echo "=== Nx versions after adjustment ==="
-          npm list --depth=0 | findstr nx
+          # The frontend is a pnpm workspace; npm cannot resolve "workspace:*" deps
+          pnpm install --frozen-lockfile
 
       - name: Pre-build frontend to avoid Tauri build issues
         run: |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -120,5 +120,6 @@
   "workspaces": [
     "apps/**/*",
     "libs/**/*"
-  ]
+  ],
+  "packageManager": "pnpm@9.15.2+sha512.93e57b0126f0df74ce6bff29680394c0ba54ec47246b9cf321f0121d8d9bb03f750a705f24edc3c1180853afd7c2c3b94196d0a3d53d3e069d9e2793ef11f321"
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -677,6 +677,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
+  libs/analytics/google-analytics: {}
+
   libs/api:
     dependencies:
       '@tauri-apps/plugin-dialog':
@@ -809,6 +811,10 @@ importers:
       '@types/howler':
         specifier: ^2.2.12
         version: 2.2.13
+
+  libs/state/credits: {}
+
+  libs/state/subscription: {}
 
   libs/tauri-api:
     dependencies:

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -2,4 +2,6 @@ packages:
   - 'apps/*'
   - 'libs/*'
   - 'libs/components/*'
+  - 'libs/state/*'
+  - 'libs/analytics/*'
 

--- a/frontend/tsconfig.base.json
+++ b/frontend/tsconfig.base.json
@@ -30,7 +30,10 @@
         "apps/artcraft/app/src/*"
       ],
       "@storyteller/api": ["libs/api/src/index.ts"],
-      "@storyteller/markdown-content": ["libs/markdown-content/src/index.ts"]
+      "@storyteller/markdown-content": ["libs/markdown-content/src/index.ts"],
+      "@storyteller/credits": ["libs/state/credits/src/index.ts"],
+      "@storyteller/subscription": ["libs/state/subscription/src/index.ts"],
+      "@storyteller/google-analytics": ["libs/analytics/google-analytics/src/index.ts"]
     }
   }
 }


### PR DESCRIPTION
The frontend migrated to pnpm workspaces in #1606, which introduced "workspace:*" dependencies. npm cannot resolve that protocol, so the macOS and Windows publish workflows fail at "npm ci" with EUNSUPPORTEDPROTOCOL, breaking production release builds on main.

Add a pinned pnpm setup step and replace the npm install block with "pnpm install --frozen-lockfile". Verified the frozen install resolves cleanly against the committed pnpm-lock.yaml.