### PR TITLE
Webapp: prompt-box fixes, in-progress recreate, model-name consistency, sticky settings

### DIFF
--- a/frontend/apps/artcraft-webapp/src/components/generation-gallery/FailedCard.tsx
+++ b/frontend/apps/artcraft-webapp/src/components/generation-gallery/FailedCard.tsx
@@ -1,5 +1,4 @@
-import { memo, useCallback, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { memo } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faArrowRotateRight,
@@ -8,7 +7,7 @@ import {
   faXmark,
 } from "@fortawesome/pro-solid-svg-icons";
 import { getModelCreatorIconPath } from "../../lib/omni-gen-hooks";
-import { applyRecreateFromPromptToken } from "../../lib/recreate";
+import { useRecreateFromPromptToken } from "../../lib/recreate";
 
 export interface FailedCardProps {
   id: string;
@@ -40,23 +39,11 @@ export const FailedCard = memo(function FailedCard({
   recreateMediaClass,
   onDismiss,
 }: FailedCardProps) {
-  const navigate = useNavigate();
-  const [isRecreating, setIsRecreating] = useState(false);
   const iconPath = modelId ? getModelCreatorIconPath(modelId) : null;
-
-  const handleRecreate = useCallback(async () => {
-    if (!promptToken || isRecreating) return;
-    setIsRecreating(true);
-    try {
-      await applyRecreateFromPromptToken(
-        promptToken,
-        recreateMediaClass,
-        navigate,
-      );
-    } finally {
-      setIsRecreating(false);
-    }
-  }, [promptToken, recreateMediaClass, navigate, isRecreating]);
+  const { isRecreating, handleRecreate } = useRecreateFromPromptToken(
+    promptToken,
+    recreateMediaClass,
+  );
 
   return (
     <div className="relative aspect-square w-full overflow-hidden rounded-lg bg-red-500/10">

--- a/frontend/apps/artcraft-webapp/src/components/generation-gallery/FailedRow.tsx
+++ b/frontend/apps/artcraft-webapp/src/components/generation-gallery/FailedRow.tsx
@@ -1,5 +1,4 @@
-import { memo, useCallback, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { memo } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faArrowRotateRight,
@@ -9,7 +8,7 @@ import {
 } from "@fortawesome/pro-solid-svg-icons";
 import { Tooltip } from "@storyteller/ui-tooltip";
 import { getModelCreatorIconPath } from "../../lib/omni-gen-hooks";
-import { applyRecreateFromPromptToken } from "../../lib/recreate";
+import { useRecreateFromPromptToken } from "../../lib/recreate";
 import { CopyPromptButton } from "./CopyPromptButton";
 import type { FailedCardProps } from "./FailedCard";
 
@@ -25,23 +24,11 @@ export const FailedRow = memo(function FailedRow({
   recreateMediaClass,
   onDismiss,
 }: FailedCardProps) {
-  const navigate = useNavigate();
-  const [isRecreating, setIsRecreating] = useState(false);
   const iconPath = modelId ? getModelCreatorIconPath(modelId) : null;
-
-  const handleRecreate = useCallback(async () => {
-    if (!promptToken || isRecreating) return;
-    setIsRecreating(true);
-    try {
-      await applyRecreateFromPromptToken(
-        promptToken,
-        recreateMediaClass,
-        navigate,
-      );
-    } finally {
-      setIsRecreating(false);
-    }
-  }, [promptToken, recreateMediaClass, navigate, isRecreating]);
+  const { isRecreating, handleRecreate } = useRecreateFromPromptToken(
+    promptToken,
+    recreateMediaClass,
+  );
 
   return (
     <div className="flex items-center gap-3 rounded-lg px-2.5 py-2">

--- a/frontend/apps/artcraft-webapp/src/components/generation-gallery/GenerationGalleryGrid.tsx
+++ b/frontend/apps/artcraft-webapp/src/components/generation-gallery/GenerationGalleryGrid.tsx
@@ -74,6 +74,8 @@ export function GenerationGalleryGrid({
                 progress={entry.job.progress}
                 estimatedTimeLeftMs={entry.job.estimatedTimeLeftMs}
                 batchCount={entry.job.batchCount}
+                promptToken={entry.job.promptToken}
+                recreateMediaClass={entry.job.mediaClass}
               />
             )}
             {entry.kind === "failed" && (

--- a/frontend/apps/artcraft-webapp/src/components/generation-gallery/GenerationGalleryList.tsx
+++ b/frontend/apps/artcraft-webapp/src/components/generation-gallery/GenerationGalleryList.tsx
@@ -102,6 +102,8 @@ export function GenerationGalleryList({
                 progress={entry.job.progress}
                 estimatedTimeLeftMs={entry.job.estimatedTimeLeftMs}
                 batchCount={entry.job.batchCount}
+                promptToken={entry.job.promptToken}
+                recreateMediaClass={entry.job.mediaClass}
               />
             );
           }

--- a/frontend/apps/artcraft-webapp/src/components/generation-gallery/PendingCard.tsx
+++ b/frontend/apps/artcraft-webapp/src/components/generation-gallery/PendingCard.tsx
@@ -1,7 +1,12 @@
 import { memo } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSpinnerThird } from "@fortawesome/pro-solid-svg-icons";
+import {
+  faArrowRotateRight,
+  faSpinnerThird,
+} from "@fortawesome/pro-solid-svg-icons";
+import { Tooltip } from "@storyteller/ui-tooltip";
 import { getModelCreatorIconPath } from "../../lib/omni-gen-hooks";
+import { useRecreateFromPromptToken } from "../../lib/recreate";
 import { derivePendingStatus } from "./pending-status";
 
 export interface PendingCardProps {
@@ -12,6 +17,9 @@ export interface PendingCardProps {
   progress?: number;
   estimatedTimeLeftMs?: number;
   batchCount?: number;
+  // Prompt token + media class enable the "Recreate" action mid-generation.
+  promptToken?: string;
+  recreateMediaClass: "image" | "video";
 }
 
 export const PendingCard = memo(function PendingCard({
@@ -21,6 +29,8 @@ export const PendingCard = memo(function PendingCard({
   progress,
   estimatedTimeLeftMs,
   batchCount,
+  promptToken,
+  recreateMediaClass,
 }: PendingCardProps) {
   const { progressPercent, timeLabel } = derivePendingStatus(
     progress,
@@ -28,9 +38,13 @@ export const PendingCard = memo(function PendingCard({
   );
 
   const iconPath = getModelCreatorIconPath(modelId);
+  const { isRecreating, handleRecreate } = useRecreateFromPromptToken(
+    promptToken,
+    recreateMediaClass,
+  );
 
   return (
-    <div className="relative aspect-square w-full overflow-hidden rounded-lg bg-white/[0.03]">
+    <div className="group relative aspect-square w-full overflow-hidden rounded-lg bg-white/[0.03]">
       <div className="animate-shimmer h-full w-full" />
       {batchCount != null && batchCount > 1 && (
         <div className="absolute left-2 right-2 top-2 z-10 rounded-md bg-black/60 px-2.5 py-1.5 text-center text-[10px] leading-snug text-white/70 backdrop-blur-sm">
@@ -52,9 +66,27 @@ export const PendingCard = memo(function PendingCard({
         )}
       </div>
       <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 via-black/40 to-transparent px-3 pb-2.5 pt-8">
-        <p className="line-clamp-3 text-xs leading-relaxed text-white/80">
-          {prompt}
-        </p>
+        <div className="flex items-start gap-2">
+          <p className="line-clamp-3 min-w-0 flex-1 text-xs leading-relaxed text-white/80">
+            {prompt}
+          </p>
+          {promptToken && (
+            <Tooltip content="Recreate" position="top">
+              <button
+                type="button"
+                onClick={handleRecreate}
+                disabled={isRecreating}
+                aria-label="Recreate"
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-white/70 opacity-0 transition hover:bg-white/15 hover:text-white focus-visible:opacity-100 group-hover:opacity-100 disabled:opacity-60"
+              >
+                <FontAwesomeIcon
+                  icon={isRecreating ? faSpinnerThird : faArrowRotateRight}
+                  className={`text-sm ${isRecreating ? "animate-spin" : ""}`}
+                />
+              </button>
+            </Tooltip>
+          )}
+        </div>
         <div className="mt-1.5 flex items-center gap-1.5">
           <img
             src={iconPath}

--- a/frontend/apps/artcraft-webapp/src/components/generation-gallery/PendingRow.tsx
+++ b/frontend/apps/artcraft-webapp/src/components/generation-gallery/PendingRow.tsx
@@ -1,7 +1,12 @@
 import { memo } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSpinnerThird } from "@fortawesome/pro-solid-svg-icons";
+import {
+  faArrowRotateRight,
+  faSpinnerThird,
+} from "@fortawesome/pro-solid-svg-icons";
+import { Tooltip } from "@storyteller/ui-tooltip";
 import { getModelCreatorIconPath } from "../../lib/omni-gen-hooks";
+import { useRecreateFromPromptToken } from "../../lib/recreate";
 import { CopyPromptButton } from "./CopyPromptButton";
 import { derivePendingStatus } from "./pending-status";
 import type { PendingCardProps } from "./PendingCard";
@@ -13,15 +18,21 @@ export const PendingRow = memo(function PendingRow({
   progress,
   estimatedTimeLeftMs,
   batchCount,
+  promptToken,
+  recreateMediaClass,
 }: PendingCardProps) {
   const { progressPercent, timeLabel } = derivePendingStatus(
     progress,
     estimatedTimeLeftMs,
   );
   const iconPath = getModelCreatorIconPath(modelId);
+  const { isRecreating, handleRecreate } = useRecreateFromPromptToken(
+    promptToken,
+    recreateMediaClass,
+  );
 
   return (
-    <div className="flex items-center gap-3 rounded-lg px-2.5 py-2">
+    <div className="group flex items-center gap-3 rounded-lg px-2.5 py-2">
       {/* Thumbnail placeholder */}
       <div className="relative size-[100px] shrink-0 overflow-hidden rounded-md bg-white/[0.03] leading-none">
         <div className="animate-shimmer h-full w-full" />
@@ -61,6 +72,26 @@ export const PendingRow = memo(function PendingRow({
               <span className="text-white/25">·</span>
               <span className="shrink-0">{batchCount} videos</span>
             </>
+          )}
+          {/* Recreate is hover-revealed on desktop (always visible on mobile),
+              mirroring the completed GalleryRow's quick actions. */}
+          {promptToken && (
+            <div className="flex shrink-0 items-center sm:ms-1 sm:opacity-0 transition-opacity sm:group-hover:opacity-100 sm:focus-within:opacity-100">
+              <Tooltip content="Recreate" position="top">
+                <button
+                  type="button"
+                  onClick={handleRecreate}
+                  disabled={isRecreating}
+                  aria-label="Recreate"
+                  className="flex h-7 w-7 items-center justify-center rounded-md text-white/60 transition-colors hover:bg-white/10 hover:text-white disabled:opacity-60"
+                >
+                  <FontAwesomeIcon
+                    icon={isRecreating ? faSpinnerThird : faArrowRotateRight}
+                    className={`text-sm ${isRecreating ? "animate-spin" : ""}`}
+                  />
+                </button>
+              </Tooltip>
+            </div>
           )}
         </div>
         {(progressPercent != null || timeLabel) && (

--- a/frontend/apps/artcraft-webapp/src/components/generation-gallery/useGenerationJobs.ts
+++ b/frontend/apps/artcraft-webapp/src/components/generation-gallery/useGenerationJobs.ts
@@ -21,6 +21,10 @@ export interface InProgressJob {
   estimatedTimeLeftMs?: number;
   createdAt: string;
   batchCount?: number;
+  // Prompt token + media class enable the "Recreate" action while the job is
+  // still running, mirroring the failed/completed cards.
+  promptToken?: string;
+  mediaClass: "image" | "video";
 }
 
 export interface FailedJob {
@@ -143,6 +147,8 @@ function jobToInProgress(
     progress,
     estimatedTimeLeftMs,
     createdAt: job.created_at,
+    promptToken: job.request.maybe_prompt_token ?? undefined,
+    mediaClass: isVideo ? "video" : "image",
   };
 }
 

--- a/frontend/apps/artcraft-webapp/src/components/topbar/task-queue.tsx
+++ b/frontend/apps/artcraft-webapp/src/components/topbar/task-queue.tsx
@@ -12,6 +12,7 @@ import {
   faCircleExclamation,
   faCopy,
   faCheck,
+  faArrowRotateRight,
 } from "@fortawesome/pro-solid-svg-icons";
 import { Modal } from "@storyteller/ui-modal";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -30,11 +31,14 @@ import { ActionReminderModal } from "@storyteller/ui-action-reminder-modal";
 import { Lightbox } from "../lightbox/lightbox";
 import { showToast } from "../toast/toast";
 import { getModelCreatorIconPath } from "../../lib/omni-gen-hooks";
+import { useRecreateFromPromptToken } from "../../lib/recreate";
 import { getMediaThumbnail, THUMBNAIL_SIZES } from "@storyteller/common";
 import { twMerge } from "tailwind-merge";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
+// `promptToken` + `mediaClass` power the "Recreate" action shared with the
+// create-page gallery cards. Present on every task state.
 type InProgressTask = {
   id: string;
   title: string;
@@ -45,6 +49,8 @@ type InProgressTask = {
   estimatedTimeLeftMs?: number;
   modelType?: string;
   prompt?: string;
+  promptToken?: string;
+  mediaClass: "image" | "video";
 };
 
 type CompletedTask = {
@@ -57,6 +63,8 @@ type CompletedTask = {
   imageUrls?: string[];
   mediaTokens?: string[];
   prompt?: string;
+  promptToken?: string;
+  mediaClass: "image" | "video";
 };
 
 type FailedTask = {
@@ -68,6 +76,8 @@ type FailedTask = {
   failureReason?: string;
   failureMessage?: string;
   prompt?: string;
+  promptToken?: string;
+  mediaClass: "image" | "video";
 };
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -200,6 +210,42 @@ const CopyPromptButton = ({ prompt }: { prompt: string }) => {
   );
 };
 
+const RecreateTaskButton = ({
+  promptToken,
+  mediaClass,
+}: {
+  promptToken?: string;
+  mediaClass: "image" | "video";
+}) => {
+  const { isRecreating, handleRecreate } = useRecreateFromPromptToken(
+    promptToken,
+    mediaClass,
+  );
+  if (!promptToken) return null;
+  return (
+    <Tooltip
+      content="Recreate"
+      position="bottom"
+      strategy="fixed"
+      className="text-xs"
+      zIndex={50}
+      delay={300}
+    >
+      <button
+        className="flex h-6 w-6 items-center justify-center rounded-full text-base-fg/60 hover:bg-ui-controls disabled:opacity-60"
+        aria-label="Recreate"
+        disabled={isRecreating}
+        onClick={handleRecreate}
+      >
+        <FontAwesomeIcon
+          icon={isRecreating ? faSpinnerThird : faArrowRotateRight}
+          className={isRecreating ? "animate-spin" : ""}
+        />
+      </button>
+    </Tooltip>
+  );
+};
+
 // ── Card Components ────────────────────────────────────────────────────────
 
 const InProgressCard = ({
@@ -267,6 +313,10 @@ const InProgressCard = ({
           {task.prompt && <PromptLine prompt={task.prompt} className="mt-0" />}
         </div>
         <div className="ml-auto flex shrink-0 items-center gap-1">
+          <RecreateTaskButton
+            promptToken={task.promptToken}
+            mediaClass={task.mediaClass}
+          />
           {task.prompt && <CopyPromptButton prompt={task.prompt} />}
           {onDismiss && (
             <button
@@ -335,6 +385,10 @@ const CompletedCard = ({
         {task.prompt && <PromptLine prompt={task.prompt} />}
       </div>
       <div className="ml-auto flex shrink-0 items-center gap-1">
+        <RecreateTaskButton
+          promptToken={task.promptToken}
+          mediaClass={task.mediaClass}
+        />
         {task.prompt && <CopyPromptButton prompt={task.prompt} />}
         {onDismiss && (
           <button
@@ -424,6 +478,10 @@ const FailedCard = ({
           )}
         </div>
         <div className="ml-auto flex shrink-0 items-center gap-1">
+          <RecreateTaskButton
+            promptToken={task.promptToken}
+            mediaClass={task.mediaClass}
+          />
           {task.prompt && <CopyPromptButton prompt={task.prompt} />}
           {onDismiss && (
             <button
@@ -444,6 +502,12 @@ const FailedCard = ({
 };
 
 // ── Job → Task transformers ────────────────────────────────────────────────
+
+function getTaskMediaClass(job: Job): "image" | "video" {
+  return job.request.inference_category?.toLowerCase().includes("video")
+    ? "video"
+    : "image";
+}
 
 function getPrompt(job: Job, promptsMap?: Map<string, Prompts>): string {
   const promptToken = job.request.maybe_prompt_token;
@@ -549,6 +613,8 @@ function jobsToInProgress(
         estimatedTimeLeftMs,
         modelType: modelType ?? undefined,
         prompt: getPrompt(j, promptsMap) || undefined,
+        promptToken: promptToken ?? undefined,
+        mediaClass: getTaskMediaClass(j),
       };
     });
 
@@ -572,11 +638,7 @@ function jobsToCompleted(
     )
     .map((j): CompletedTask => {
       const cdnUrl = j.maybe_result?.media_links?.cdn_url;
-      const mediaClass = j.request.inference_category
-        ?.toLowerCase()
-        .includes("video")
-        ? "video"
-        : "image";
+      const mediaClass = getTaskMediaClass(j);
       const thumbnailUrl =
         getMediaThumbnail(j.maybe_result?.media_links, mediaClass, {
           size: THUMBNAIL_SIZES.MEDIUM,
@@ -597,6 +659,8 @@ function jobsToCompleted(
           ? [j.maybe_result.entity_token]
           : [],
         prompt: getPrompt(j, promptsMap) || undefined,
+        promptToken: j.request.maybe_prompt_token ?? undefined,
+        mediaClass,
       };
     });
 }
@@ -634,6 +698,8 @@ function jobsToFailed(
         failureReason,
         failureMessage,
         prompt: getPrompt(j, promptsMap) || undefined,
+        promptToken: j.request.maybe_prompt_token ?? undefined,
+        mediaClass: getTaskMediaClass(j),
       };
     });
 }

--- a/frontend/apps/artcraft-webapp/src/lib/omni-gen-hooks.ts
+++ b/frontend/apps/artcraft-webapp/src/lib/omni-gen-hooks.ts
@@ -4,6 +4,7 @@ import type {
   OmniGenImageModelInfo,
   OmniGenVideoModelInfo,
 } from "@storyteller/api";
+import { getModelDisplayName as getCanonicalModelDisplayName } from "@storyteller/model-list";
 
 // ── Singleton caches (fetch once per session) ────────────────────────────
 
@@ -165,58 +166,15 @@ export function useOmniGenVideoModels(): {
 
 // ── Display name helper ──────────────────────────────────────────────────
 
-const MODEL_DISPLAY_NAMES: Record<string, string> = {
-  // Image models
-  flux_1_dev: "Flux 1 Dev",
-  flux_1_schnell: "Flux 1 Schnell",
-  flux_pro_1p1: "Flux Pro 1.1",
-  flux_pro_1p1_ultra: "Flux Pro 1.1 Ultra",
-  gpt_image_1p5: "GPT Image 1.5",
-  gpt_image_2: "GPT Image 2",
-  midjourney_7: "Midjourney v7",
-  midjourney_7_niji: "Midjourney v7 Niji (Anime)",
-  midjourney_8: "Midjourney v8",
-  nano_banana: "Nano Banana",
-  nano_banana_2: "Nano Banana 2",
-  nano_banana_pro: "Nano Banana Pro",
-  seedream_4: "Seedream 4",
-  seedream_4p5: "Seedream 4.5",
-  seedream_5_lite: "Seedream 5 Lite",
-  // Video models
-  grok_video: "Grok Video",
-  grok_imagine_video: "Grok Imagine",
-  grok_imagine_video_1p5: "Grok Imagine 1.5",
-  kling_1p6_pro: "Kling 1.6 Pro",
-  kling_2p1_pro: "Kling 2.1 Pro",
-  kling_2p1_master: "Kling 2.1 Master",
-  kling_2p5_turbo_pro: "Kling 2.5 Turbo Pro",
-  kling_2p6_pro: "Kling 2.6 Pro",
-  kling_3p0_standard: "Kling 3.0 Standard",
-  kling_3p0_pro: "Kling 3.0 Pro",
-  seedance_1p0_lite: "Seedance 1.0 Lite",
-  seedance_1p5_pro: "Seedance 1.5 Pro",
-  seedance_2p0: "Seedance 2.0",
-  seedance_2p0_fast: "Seedance 2.0 Fast",
-  seedance_2p0_bp: "Seedance 2.0 Plus",
-  seedance_2p0_bp_fast: "Seedance 2.0 Plus Fast",
-  happy_horse_1p0: "Happy Horse 1.0",
-  sora_2: "Sora 2",
-  sora_2_pro: "Sora 2 Pro",
-  veo_2: "Google Veo 2",
-  veo_3: "Google Veo 3",
-  veo_3_fast: "Google Veo 3 Fast",
-  veo_3p1: "Google Veo 3.1",
-  veo_3p1_fast: "Google Veo 3.1 Fast",
-  // Edit / VFX models
-  switch_x: "SwitchX",
-};
-
+// The actual name map lives in `@storyteller/model-list` so the gallery cards,
+// task queue, and lightbox all resolve names from a single source of truth.
+// The API-provided `fullName` (when present) still wins over the static map.
 export function getModelDisplayName(
   modelId: string,
   fullName?: string | null,
 ): string {
   if (fullName) return fullName;
-  return MODEL_DISPLAY_NAMES[modelId] ?? modelId;
+  return getCanonicalModelDisplayName(modelId);
 }
 
 // ── Description / info helpers ─────────────────────────────────────────────

--- a/frontend/apps/artcraft-webapp/src/lib/recreate.ts
+++ b/frontend/apps/artcraft-webapp/src/lib/recreate.ts
@@ -1,4 +1,5 @@
-import type { NavigateFunction } from "react-router-dom";
+import { useCallback, useState, type MouseEvent } from "react";
+import { useNavigate, type NavigateFunction } from "react-router-dom";
 import {
   MediaFilesApi,
   PromptsApi,
@@ -99,6 +100,38 @@ export async function applyRecreateFromPromptToken(
   } catch {
     toast.error("Failed to load recreate data");
   }
+}
+
+// Hook wrapping the prompt-token recreate flow with its own loading state.
+// Shared by every card that recreates from a known prompt token (in-progress /
+// failed gallery cards and the task-queue rows) so the button behaves
+// identically everywhere. `handleRecreate` swallows the click so it doesn't
+// bubble to a parent card's onClick.
+export function useRecreateFromPromptToken(
+  promptToken: string | undefined,
+  mediaClass: RecreateMediaClass,
+): {
+  isRecreating: boolean;
+  handleRecreate: (e?: MouseEvent) => void;
+} {
+  const navigate = useNavigate();
+  const [isRecreating, setIsRecreating] = useState(false);
+
+  const handleRecreate = useCallback(
+    async (e?: MouseEvent) => {
+      e?.stopPropagation();
+      if (!promptToken || isRecreating) return;
+      setIsRecreating(true);
+      try {
+        await applyRecreateFromPromptToken(promptToken, mediaClass, navigate);
+      } finally {
+        setIsRecreating(false);
+      }
+    },
+    [promptToken, mediaClass, navigate, isRecreating],
+  );
+
+  return { isRecreating, handleRecreate };
 }
 
 function applyRecreateFromPromptData(

--- a/frontend/apps/artcraft-webapp/src/lib/resolve-model-setting.ts
+++ b/frontend/apps/artcraft-webapp/src/lib/resolve-model-setting.ts
@@ -1,0 +1,47 @@
+// Sticky prompt-box settings across model switches.
+//
+// The user's chosen value is kept in the store untouched when models change.
+// At read time we resolve it against the *current* model's supported options:
+// keep the choice if the model supports it, otherwise fall back to the model's
+// default (for display + generation only) without overwriting the stored
+// preference. That way returning to a model that supports the original value
+// restores it, while a value both models share (e.g. 16:9) stays put.
+
+// Resolve a preferred string option (aspect ratio, resolution, quality) against
+// a model's supported list. Returns the preference when supported, else the
+// model default when valid, else the first option. When the model exposes no
+// options for this setting, the preference (or default) passes through unchanged.
+export function resolveModelOption(
+  preferred: string | undefined,
+  options: readonly string[] | null | undefined,
+  modelDefault: string | null | undefined,
+): string | undefined {
+  if (!options || options.length === 0) {
+    return preferred ?? modelDefault ?? undefined;
+  }
+  if (preferred && options.includes(preferred)) return preferred;
+  if (modelDefault && options.includes(modelDefault)) return modelDefault;
+  return options[0];
+}
+
+// Resolve a preferred batch count against a model's options/limits. Clamps to
+// [1, max], then snaps to the nearest supported option ≤ the preference (so a
+// user who wanted 4 keeps the highest the model allows), falling back to the
+// model default or smallest option.
+export function resolveModelCount(
+  preferred: number,
+  options: readonly number[] | null | undefined,
+  max: number | null | undefined,
+  modelDefault: number | null | undefined,
+): number {
+  const cap = max ?? 4;
+  const clamped = Math.min(Math.max(1, preferred), cap);
+  if (!options || options.length === 0) return clamped;
+  if (options.includes(clamped)) return clamped;
+
+  const sorted = [...options].sort((a, b) => a - b);
+  const atOrBelow = sorted.filter((o) => o <= clamped);
+  if (atOrBelow.length) return atOrBelow[atOrBelow.length - 1];
+  if (modelDefault != null && options.includes(modelDefault)) return modelDefault;
+  return sorted[0];
+}

--- a/frontend/apps/artcraft-webapp/src/pages/create-image/create-image.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/create-image/create-image.tsx
@@ -555,7 +555,7 @@ export default function CreateImage() {
       promptBox={
         <div
           ref={promptBoxRef}
-          className="animate-fade-in-up fixed bottom-2 sm:bottom-3 right-0 z-30 mx-auto w-full max-w-5xl px-2 sm:px-4 transition-[left] duration-200 ease-linear"
+          className="animate-fade-in-up fixed bottom-2 sm:bottom-3 right-0 z-30 mx-auto max-w-5xl px-2 sm:px-4 transition-[left] duration-200 ease-linear"
           style={{
             animationDelay: "150ms",
             left: "var(--ac-sidebar-offset, 0px)",

--- a/frontend/apps/artcraft-webapp/src/pages/create-image/create-image.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/create-image/create-image.tsx
@@ -47,6 +47,10 @@ import {
 } from "./components/QualityPicker";
 import { useImageCostEstimate } from "../../lib/cost-estimate-api";
 import {
+  resolveModelOption,
+  resolveModelCount,
+} from "../../lib/resolve-model-setting";
+import {
   useOmniGenImageModels,
   getModelCreatorIconPath,
   getModelDescription,
@@ -115,22 +119,46 @@ export default function CreateImage() {
 
   const prompt = ui.prompt;
   const setPrompt = useCallback((v: string) => setUi({ prompt: v }), [setUi]);
-  const aspectRatio = ui.aspectRatio;
+
+  // Settings are sticky across model switches: the store holds the user's
+  // chosen value (set by the setters below) untouched, and we resolve an
+  // *effective* value against the current model here — keeping the choice when
+  // supported, otherwise falling back to the model's default for display +
+  // generation only. See lib/resolve-model-setting.
+  const aspectRatio =
+    resolveModelOption(
+      ui.aspectRatio,
+      selectedModel?.aspect_ratio_options,
+      selectedModel?.aspect_ratio_default,
+    ) ?? ui.aspectRatio;
   const setAspectRatio = useCallback(
     (v: string) => setUi({ aspectRatio: v }),
     [setUi],
   );
-  const numImages = ui.numImages;
+  const numImages = resolveModelCount(
+    ui.numImages,
+    selectedModel?.batch_size_options,
+    selectedModel?.batch_size_max,
+    selectedModel?.batch_size_default,
+  );
   const setNumImages = useCallback(
     (v: number) => setUi({ numImages: v }),
     [setUi],
   );
-  const resolution = ui.resolution;
+  const resolution = resolveModelOption(
+    ui.resolution,
+    selectedModel?.resolution_options,
+    selectedModel?.resolution_default,
+  );
   const setResolution = useCallback(
     (v: string | undefined) => setUi({ resolution: v }),
     [setUi],
   );
-  const quality = ui.quality;
+  const quality = resolveModelOption(
+    ui.quality,
+    selectedModel?.quality_options,
+    selectedModel?.default_quality,
+  );
   const setQuality = useCallback(
     (v: string | undefined) => setUi({ quality: v }),
     [setUi],
@@ -276,16 +304,10 @@ export default function CreateImage() {
     (item: PopoverItem) => {
       const model = item.action ? _modelLookup.get(item.action) : undefined;
       if (!model) return;
-      setUi({
-        selectedModelId: model.model,
-        aspectRatio: model.aspect_ratio_default ?? "square",
-        numImages: Math.min(
-          model.batch_size_max ?? 4,
-          model.batch_size_default ?? 1,
-        ),
-        resolution: model.resolution_default ?? undefined,
-        quality: model.default_quality ?? undefined,
-      });
+      // Only switch the model — aspect ratio / count / resolution / quality are
+      // preserved and resolved against the new model at read time, so the user's
+      // choices survive model switches instead of resetting to defaults.
+      setUi({ selectedModelId: model.model });
     },
     [setUi],
   );

--- a/frontend/apps/artcraft-webapp/src/pages/create-video/create-video.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/create-video/create-video.tsx
@@ -54,6 +54,10 @@ import {
 import { GenerationCountPicker } from "../create-image/components/GenerationCountPicker";
 import { useVideoCostEstimate } from "../../lib/cost-estimate-api";
 import {
+  resolveModelOption,
+  resolveModelCount,
+} from "../../lib/resolve-model-setting";
+import {
   useOmniGenVideoModels,
   getModelCreatorIconPath,
   getModelDescription,
@@ -255,7 +259,17 @@ export default function CreateVideo() {
 
   const prompt = ui.prompt;
   const setPrompt = useCallback((v: string) => setUi({ prompt: v }), [setUi]);
-  const selectedSize = ui.selectedSize;
+
+  // Settings are sticky across model switches: the store keeps the user's
+  // chosen value untouched; we resolve an *effective* value against the current
+  // model here (keep when supported, else fall back to the model default for
+  // display + generation). See lib/resolve-model-setting.
+  const selectedSize =
+    resolveModelOption(
+      ui.selectedSize,
+      selectedModel?.aspect_ratio_options,
+      selectedModel?.aspect_ratio_default,
+    ) ?? ui.selectedSize;
   const setSelectedSize = useCallback(
     (v: string) => setUi({ selectedSize: v }),
     [setUi],
@@ -265,13 +279,23 @@ export default function CreateVideo() {
     (v: number | null) => setUi({ duration: v }),
     [setUi],
   );
-  const resolution = ui.resolution ?? selectedModel?.resolution_default ?? null;
+  const resolution =
+    resolveModelOption(
+      ui.resolution ?? undefined,
+      selectedModel?.resolution_options,
+      selectedModel?.resolution_default,
+    ) ?? null;
   const setResolution = useCallback(
     (v: string | null) => setUi({ resolution: v }),
     [setUi],
   );
   const generateWithSound = ui.generateWithSound;
-  const numVideos = ui.numVideos;
+  const numVideos = resolveModelCount(
+    ui.numVideos,
+    selectedModel?.batch_size_options,
+    selectedModel?.batch_size_max,
+    selectedModel?.batch_size_default,
+  );
   const setNumVideos = useCallback(
     (v: number) => setUi({ numVideos: v }),
     [setUi],
@@ -376,6 +400,16 @@ export default function CreateVideo() {
   const needsImage =
     !!selectedModel?.starting_keyframe_required && referenceImages.length === 0;
 
+  // Effective duration: keep the user's chosen seconds when the model supports
+  // them, else clamp/snap to this model's range for display + generation. The
+  // stored preference (ui.duration) stays untouched, so switching back restores
+  // it — same sticky behavior as the other settings.
+  const effectiveDuration = selectedModel
+    ? (resolveDurationForModel(selectedModel, duration, isReferenceMode) ??
+      selectedModel.duration_seconds_default ??
+      5)
+    : (duration ?? 5);
+
   // Jobs + gallery
   const jobs = useGenerationJobs({ mediaType: "video", enabled: !!user });
   const gallery = useGalleryData({
@@ -424,7 +458,7 @@ export default function CreateVideo() {
     model: selectedModel?.model ?? "",
     aspectRatio: selectedSize,
     resolution,
-    duration: duration ?? selectedModel?.duration_seconds_default ?? null,
+    duration: effectiveDuration,
     numVideos,
     hasStartFrame: !isReferenceMode && referenceImages.length > 0,
     hasEndFrame: !isReferenceMode && hasEndFrame && !!endFrameImage,
@@ -509,8 +543,6 @@ export default function CreateVideo() {
     }
     return null;
   }, [selectedModel, isReferenceMode]);
-  const effectiveDuration =
-    duration ?? selectedModel?.duration_seconds_default ?? 5;
   const [localDuration, setLocalDuration] = useState(effectiveDuration);
   const durationTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   useEffect(() => {
@@ -655,23 +687,12 @@ export default function CreateVideo() {
           ? "reference"
           : "keyframe";
 
-      const nextDuration = resolveDurationForModel(
-        model,
-        currentState.duration,
-        nextInputMode === "reference",
-      );
-
+      // Aspect ratio / resolution / count / duration / sound are preserved and
+      // resolved against the new model at read time, so the user's choices
+      // survive model switches. Only input mode (capability-bound) is recomputed.
       setUi({
         selectedModelId: model.model,
-        selectedSize: model.aspect_ratio_default ?? "wide_sixteen_by_nine",
-        duration: nextDuration,
-        resolution: model.resolution_default ?? null,
-        generateWithSound: false,
         inputMode: nextInputMode,
-        numVideos: Math.min(
-          model.batch_size_max ?? 4,
-          model.batch_size_default ?? 1,
-        ),
       });
 
       // Only clear media that the new model can't use in any mode.
@@ -869,7 +890,7 @@ export default function CreateVideo() {
       model: selectedModel.model,
       numVideos,
       aspectRatio: selectedSize,
-      duration: duration ?? selectedModel.duration_seconds_default ?? undefined,
+      duration: effectiveDuration,
       resolution: hasResolutionOptions
         ? (resolution ?? selectedModel.resolution_default ?? undefined)
         : undefined,
@@ -961,7 +982,7 @@ export default function CreateVideo() {
     selectedModel,
     selectedSize,
     numVideos,
-    duration,
+    effectiveDuration,
     resolution,
     generateWithSound,
     hasResolutionOptions,

--- a/frontend/apps/artcraft-webapp/src/pages/create-video/create-video.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/create-video/create-video.tsx
@@ -1241,7 +1241,7 @@ export default function CreateVideo() {
       promptBox={
         <div
           ref={promptBoxRef}
-          className="animate-fade-in-up fixed bottom-2 sm:bottom-3 right-0 z-30 mx-auto w-full max-w-5xl px-2 sm:px-4 transition-[left] duration-200 ease-linear"
+          className="animate-fade-in-up fixed bottom-2 sm:bottom-3 right-0 z-30 mx-auto max-w-5xl px-2 sm:px-4 transition-[left] duration-200 ease-linear"
           style={{
             animationDelay: "150ms",
             left: "var(--ac-sidebar-offset, 0px)",

--- a/frontend/libs/model-list/src/lib/classes/metadata/ModelMapping.ts
+++ b/frontend/libs/model-list/src/lib/classes/metadata/ModelMapping.ts
@@ -79,6 +79,10 @@ export const MODEL_TYPE_TO_CREATOR: Record<string, ModelCreator> = {
   midjourney_v7: ModelCreator.Midjourney,
   midjourney_v7_raw: ModelCreator.Midjourney,
   midjourney_v7_draft_raw: ModelCreator.Midjourney,
+  // Underscore-numbered IDs the backend actually sends for current MJ models
+  midjourney_7: ModelCreator.Midjourney,
+  midjourney_7_niji: ModelCreator.Midjourney,
+  midjourney_8: ModelCreator.Midjourney,
   // Angles
   flux_2_lora_angles: ModelCreator.BlackForestLabs,
   qwen_edit_2511_angles: ModelCreator.Alibaba,
@@ -213,7 +217,7 @@ export const getModelDisplayName = (modelType: string): string => {
     seedream_5_lite: "Seedream 5 Lite",
 
     // Google
-    veo_2: "Veo 2",
+    veo_2: "Google Veo 2",
     veo_3: "Google Veo 3",
     veo_3_fast: "Google Veo 3 Fast",
     veo_3p1: "Google Veo 3.1",
@@ -251,6 +255,10 @@ export const getModelDisplayName = (modelType: string): string => {
     midjourney_v7: "Midjourney V7",
     midjourney_v7_raw: "Midjourney V7 (Raw)",
     midjourney_v7_draft_raw: "Midjourney V7 (Draft Raw)",
+    // Underscore-numbered IDs the backend actually sends for current MJ models
+    midjourney_7: "Midjourney v7",
+    midjourney_7_niji: "Midjourney v7 Niji (Anime)",
+    midjourney_8: "Midjourney v8",
 
     // Angles
     flux_2_lora_angles: "Flux 2 LoRA Angles",


### PR DESCRIPTION
### Prompt box
- Fix prompt box overflowing past the viewport at some desktop widths (Generate button hidden) - removed `w-full` so it sizes to the content area beside the sidebar (create-image + create-video).

### Recreate action
- Add **Recreate** to in-progress jobs in the create-page gallery (grid + list) and the task queue - previously only on completed/failed.
- Task queue had no Recreate at all; added it to all three states (in-progress/completed/failed) for consistency.
- Recreate on the in-progress grid card sits bottom-right inline with the prompt; in-progress list row reveals it on hover (matching completed rows).
- Extract shared `useRecreateFromPromptToken` hook; refactor FailedCard/FailedRow onto it (DRY).

### Model display names
- Consolidate to a single source of truth: webapp `getModelDisplayName` now delegates to `@storyteller/model-list` (removed the duplicate local map). Gallery, task queue, and lightbox now agree.
- Fix missing names: `gpt_image_1` (gallery) and Midjourney in the lightbox - added `midjourney_7` / `midjourney_7_niji` / `midjourney_8` to the model-list name + creator-icon maps; aligned `veo_2` → "Google Veo 2".

### Sticky prompt settings across model switches
- Prompt-box settings no longer reset when switching models - the user's choice persists and is resolved against the new model (kept if supported, else falls back for display/generation only, without losing the preference).
- Covers aspect ratio, count, resolution, quality (image) and aspect ratio, resolution, count, duration, sound (video).
- Add `lib/resolve-model-setting.ts` (`resolveModelOption` / `resolveModelCount`); `handleModelChange` now only switches the model (+ capability-bound input mode on video).