### PR TITLE
Webapp: OmniGen outage handling + toast fixes

### DIFF
--- a/frontend/apps/artcraft-webapp/src/components/toast/toast.tsx
+++ b/frontend/apps/artcraft-webapp/src/components/toast/toast.tsx
@@ -92,7 +92,7 @@ export const ToastContainer = () => {
       {toasts.map((toast) => (
         <div
           key={toast.id}
-          className="glass flex items-center gap-3 rounded-xl px-4 py-2.5 text-sm text-white animate-toast-in"
+          className="glass flex max-w-full items-center gap-3 rounded-xl px-4 py-2.5 text-sm text-white animate-toast-in sm:max-w-md"
         >
           <div
             className={`flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full ${
@@ -104,7 +104,7 @@ export const ToastContainer = () => {
               className="h-3 w-3 text-white"
             />
           </div>
-          <span className="flex-1 text-white/90 whitespace-nowrap overflow-hidden text-ellipsis">
+          <span className="min-w-0 break-words text-white/90">
             {toast.message}
           </span>
           <button

--- a/frontend/apps/artcraft-webapp/src/components/toast/toast.tsx
+++ b/frontend/apps/artcraft-webapp/src/components/toast/toast.tsx
@@ -88,7 +88,7 @@ export const ToastContainer = () => {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed sm:top-16 top-14 left-1/2 -translate-x-1/2 sm:left-auto sm:translate-x-0 sm:right-5 z-[100] flex flex-col items-center sm:items-end gap-2 px-4 sm:px-0 max-w-[calc(100vw-1rem)]">
+    <div className="fixed top-14 left-2 right-2 z-[100] flex flex-col items-center gap-2 sm:top-16 sm:left-auto sm:right-5 sm:items-end">
       {toasts.map((toast) => (
         <div
           key={toast.id}

--- a/frontend/apps/artcraft-webapp/src/lib/omni-gen-hooks.ts
+++ b/frontend/apps/artcraft-webapp/src/lib/omni-gen-hooks.ts
@@ -5,6 +5,16 @@ import type {
   OmniGenVideoModelInfo,
 } from "@storyteller/api";
 import { getModelDisplayName as getCanonicalModelDisplayName } from "@storyteller/model-list";
+import { toast } from "../components/toast/toast";
+
+// Shown when the OmniGen service is unavailable (e.g. returns 5xx). Separate
+// copy for the two failure points so the user knows which step failed. The
+// toast dedups on identical messages within a short window, so concurrent
+// failures surface a single notice.
+export const OMNI_MODELS_OUTAGE_MESSAGE =
+  "Couldn't load models - the generation service may be down. Try again shortly.";
+export const OMNI_GENERATE_OUTAGE_MESSAGE =
+  "Couldn't start generation - the service is temporarily unavailable. Try again shortly.";
 
 // ── Singleton caches (fetch once per session) ────────────────────────────
 
@@ -41,6 +51,7 @@ function fetchImageModelsOnce() {
       } else {
         imageModelsError = "No image models returned from API";
         console.warn("[OmniGen] Image models response:", res);
+        toast.error(OMNI_MODELS_OUTAGE_MESSAGE);
       }
       notifyImageListeners();
     },
@@ -48,6 +59,7 @@ function fetchImageModelsOnce() {
       imageModelsFetching = false;
       imageModelsError = err?.message ?? "Failed to fetch image models";
       console.error("[OmniGen] Failed to fetch image models:", err);
+      toast.error(OMNI_MODELS_OUTAGE_MESSAGE);
       notifyImageListeners();
     },
   );
@@ -66,6 +78,7 @@ function fetchVideoModelsOnce() {
       } else {
         videoModelsError = "No video models returned from API";
         console.warn("[OmniGen] Video models response:", res);
+        toast.error(OMNI_MODELS_OUTAGE_MESSAGE);
       }
       notifyVideoListeners();
     },
@@ -73,6 +86,7 @@ function fetchVideoModelsOnce() {
       videoModelsFetching = false;
       videoModelsError = err?.message ?? "Failed to fetch video models";
       console.error("[OmniGen] Failed to fetch video models:", err);
+      toast.error(OMNI_MODELS_OUTAGE_MESSAGE);
       notifyVideoListeners();
     },
   );

--- a/frontend/apps/artcraft-webapp/src/pages/create-image/create-image.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/create-image/create-image.tsx
@@ -55,7 +55,9 @@ import {
   getModelCreatorIconPath,
   getModelDescription,
   getModelInfo,
+  OMNI_GENERATE_OUTAGE_MESSAGE,
 } from "../../lib/omni-gen-hooks";
+import { toast } from "../../components/toast/toast";
 import { useSignupCta } from "../../components/signup-cta-modal";
 import { useInsufficientCredits } from "../../components/insufficient-credits-modal";
 import { faSparkles } from "@fortawesome/pro-solid-svg-icons";
@@ -370,6 +372,9 @@ export default function CreateImage() {
           dismissBatch(batchId);
           openInsufficientCredits();
         } else {
+          if (result.errorCode != null && result.errorCode >= 500) {
+            toast.error(OMNI_GENERATE_OUTAGE_MESSAGE);
+          }
           failBatch(batchId, result.error ?? "Failed to start generation");
         }
         setIsGenerating(false);

--- a/frontend/apps/artcraft-webapp/src/pages/create-video/create-video.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/create-video/create-video.tsx
@@ -62,6 +62,7 @@ import {
   getModelCreatorIconPath,
   getModelDescription,
   getModelInfo,
+  OMNI_GENERATE_OUTAGE_MESSAGE,
 } from "../../lib/omni-gen-hooks";
 import { useSignupCta } from "../../components/signup-cta-modal";
 import { useInsufficientCredits } from "../../components/insufficient-credits-modal";
@@ -934,6 +935,9 @@ export default function CreateVideo() {
           dismissBatch(batchId);
           openInsufficientCredits();
         } else {
+          if (result.errorCode != null && result.errorCode >= 500) {
+            toast.error(OMNI_GENERATE_OUTAGE_MESSAGE);
+          }
           failBatch(batchId, result.error ?? "Failed to start generation");
         }
       } else {


### PR DESCRIPTION
### Outage handling
- Show an error toast when the OmniGen service is unavailable (5xx) instead of failing silently.
- Distinct messages for the two failure points: couldn't load the model list vs. couldn't enqueue a generation.
- Model-fetch toast fires once per failed attempt (singleton fetch + message dedup); generation toast is gated to 5xx so content-policy/4xx rejections still just show the failed card and 402 still opens the credits modal.
