### PR TITLE
feat(library): marquee selection, multi-select UX, mobile polish and …

### DIFF
--- a/frontend/apps/artcraft-webapp/src/pages/library/library-folders-store.ts
+++ b/frontend/apps/artcraft-webapp/src/pages/library/library-folders-store.ts
@@ -14,6 +14,45 @@ import {
 import { getMediaThumbnail, THUMBNAIL_SIZES } from "@storyteller/common";
 import { toast } from "../../components/toast/toast";
 
+// ── Bulk selection store ────────────────────────────────────────────────────
+// Kept in its own module store (not page state) so each gallery tile can
+// subscribe to just its own membership: a marquee/selection commit re-renders
+// only the tiles whose checked state flipped, never the whole library page.
+
+interface LibrarySelectionState {
+  ids: Set<string>;
+  toggle: (id: string) => void;
+  setIds: (ids: Set<string>) => void;
+  removeIds: (ids: string[]) => void;
+  clear: () => void;
+}
+
+export const useLibrarySelectionStore = create<LibrarySelectionState>(
+  (set) => ({
+    ids: new Set<string>(),
+    toggle: (id) =>
+      set((s) => {
+        const next = new Set(s.ids);
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+        return { ids: next };
+      }),
+    setIds: (ids) => set({ ids }),
+    removeIds: (ids) =>
+      set((s) => {
+        if (!ids.some((id) => s.ids.has(id))) return s;
+        const next = new Set(s.ids);
+        ids.forEach((id) => next.delete(id));
+        return { ids: next };
+      }),
+    clear: () =>
+      set((s) => (s.ids.size === 0 ? s : { ids: new Set<string>() })),
+  }),
+);
+
 // ── Types ──────────────────────────────────────────────────────────────────
 
 /** Folder shape the UI navigates + renders by. */

--- a/frontend/apps/artcraft-webapp/src/pages/library/library.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/library/library.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Link, useParams, useNavigate, useLocation } from "react-router-dom";
 import { Button } from "@storyteller/ui-button";
@@ -15,6 +15,7 @@ import {
   GalleryDragComponent,
   FolderColorRow,
   FolderNameDialog,
+  LazyDateGroup,
   compareFolders,
   promptFolderDrop,
   FOLDER_DROP_EVENT,
@@ -44,8 +45,10 @@ import {
 import { Lightbox } from "../../components/lightbox/lightbox";
 import {
   useLibraryFoldersStore,
+  useLibrarySelectionStore,
   mapRawToGalleryItem,
   deleteLibraryMedia,
+  type UiFolder,
 } from "./library-folders-store";
 
 const PAGE_SIZE = 60;
@@ -150,12 +153,11 @@ export default function Library() {
   const [lightboxItem, setLightboxItem] = useState<GalleryItem | null>(null);
   const [lightboxOpen, setLightboxOpen] = useState(false);
 
-  // Bulk selection state
-  const [bulkSelectedIds, setBulkSelectedIds] = useState<Set<string>>(
-    () => new Set(),
-  );
-  const bulkSelectionMode = bulkSelectedIds.size > 0;
-  const [bulkFolderPopoverOpen, setBulkFolderPopoverOpen] = useState(false);
+  // Bulk selection lives in `useLibrarySelectionStore` (module store) so each
+  // tile subscribes to its own membership and the page itself never re-renders
+  // on selection changes. The page reads it via getState() in callbacks only.
+  // Clear it when leaving the library area.
+  useEffect(() => () => useLibrarySelectionStore.getState().clear(), []);
 
   const api = useMemo(() => new GalleryModalApi(), []);
 
@@ -369,52 +371,170 @@ export default function Library() {
   }, [requestFolderDrop]);
 
   // ── Bulk selection ──────────────────────────────────────────────────────────
-  const bulkSelectedIdsRef = useRef(bulkSelectedIds);
-  bulkSelectedIdsRef.current = bulkSelectedIds;
-
-  const toggleBulkSelect = useCallback((id: string) => {
-    setBulkSelectedIds((prev) => {
-      const next = new Set(prev);
-      next.has(id) ? next.delete(id) : next.add(id);
-      return next;
-    });
-  }, []);
-
-  const clearBulkSelection = useCallback(() => {
-    setBulkSelectedIds(new Set());
-    setBulkFolderPopoverOpen(false);
-  }, []);
-
-  // Stable across renders — read live values from refs (only called on drag start).
+  // Stable across renders — reads live values at call time (only on drag start).
   const getBulkDragItems = useCallback(
     () =>
       displayItemsRef.current.filter((it) =>
-        bulkSelectedIdsRef.current.has(it.id),
+        useLibrarySelectionStore.getState().ids.has(it.id),
       ),
     [],
   );
 
-  const bulkSelectedItems = useMemo(
-    () => displayItems.filter((it) => bulkSelectedIds.has(it.id)),
-    [displayItems, bulkSelectedIds],
-  );
+  // ── Marquee (drag) selection ────────────────────────────────────────────────
+  // Dragging from blank background draws a selection rectangle; tiles it covers
+  // are added to the bulk selection (additive to whatever was selected on start).
+  // Perf-sensitive: the rectangle is positioned imperatively (no React state per
+  // frame), tile rects are cached at drag start, and selection state only commits
+  // when the covered set actually changes.
+  const marqueeRef = useRef<HTMLDivElement>(null);
+  const marqueeRaf = useRef(0);
 
-  // Clear the selection whenever the view changes (filter or folder).
-  useEffect(() => {
-    setBulkSelectedIds(new Set());
-    setBulkFolderPopoverOpen(false);
-  }, [activeFilter, activeFolderId]);
+  const handleMarqueePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0 || lightboxOpen) return;
+      const target = e.target as HTMLElement;
+      // Start only on blank background — never from tiles, folder cards,
+      // controls, or opted-out chrome (header / bulk bar).
+      if (
+        target.closest(
+          "[data-media-id], [data-folder-id], button, a, input, [data-no-marquee]",
+        )
+      ) {
+        return;
+      }
 
-  const handleBulkAddToFolder = useCallback(
-    (folderId: string) => {
-      requestFolderDrop(Array.from(bulkSelectedIdsRef.current), folderId);
-      clearBulkSelection();
+      const startX = e.clientX;
+      const startY = e.clientY;
+      // No marquee on touch — a finger drag should scroll. A still tap on
+      // blank space still clears the selection below.
+      const isTouch = e.pointerType !== "mouse";
+      const base = new Set(useLibrarySelectionStore.getState().ids);
+      let applied = base;
+      let active = false;
+
+      // Tile rects are stable during the drag (no auto-scroll); cache once and
+      // refresh only if something scrolls mid-drag.
+      let tiles: {
+        id: string;
+        left: number;
+        top: number;
+        right: number;
+        bottom: number;
+      }[] = [];
+      const cacheTiles = () => {
+        tiles = [];
+        rootRef.current
+          ?.querySelectorAll<HTMLElement>("[data-media-id]")
+          .forEach((el) => {
+            const id = el.dataset.mediaId;
+            if (!id) return;
+            const r = el.getBoundingClientRect();
+            tiles.push({
+              id,
+              left: r.left,
+              top: r.top,
+              right: r.right,
+              bottom: r.bottom,
+            });
+          });
+      };
+      if (!isTouch) cacheTiles();
+
+      const applyMarquee = (cx: number, cy: number) => {
+        const left = Math.min(startX, cx);
+        const top = Math.min(startY, cy);
+        const width = Math.abs(cx - startX);
+        const height = Math.abs(cy - startY);
+        const box = marqueeRef.current;
+        if (box) {
+          box.style.display = "block";
+          box.style.left = `${left}px`;
+          box.style.top = `${top}px`;
+          box.style.width = `${width}px`;
+          box.style.height = `${height}px`;
+        }
+        const right = left + width;
+        const bottom = top + height;
+        const next = new Set(base);
+        for (const t of tiles) {
+          if (
+            t.left < right &&
+            t.right > left &&
+            t.top < bottom &&
+            t.bottom > top
+          ) {
+            next.add(t.id);
+          }
+        }
+        // Commit only when coverage changed — most frames it hasn't.
+        let changed = next.size !== applied.size;
+        if (!changed) {
+          for (const id of next) {
+            if (!applied.has(id)) {
+              changed = true;
+              break;
+            }
+          }
+        }
+        if (changed) {
+          applied = next;
+          useLibrarySelectionStore.getState().setIds(next);
+        }
+      };
+
+      const handleMove = (ev: PointerEvent) => {
+        if (isTouch) {
+          // Track movement only so a scroll gesture doesn't count as a
+          // "blank tap" (which would clear the selection on pointerup).
+          if (
+            Math.abs(ev.clientX - startX) > 10 ||
+            Math.abs(ev.clientY - startY) > 10
+          ) {
+            active = true;
+          }
+          return;
+        }
+        if (!active) {
+          // Small threshold so plain background clicks don't flash a marquee.
+          if (
+            Math.abs(ev.clientX - startX) < 5 &&
+            Math.abs(ev.clientY - startY) < 5
+          ) {
+            return;
+          }
+          active = true;
+          document.body.style.userSelect = "none";
+        }
+        cancelAnimationFrame(marqueeRaf.current);
+        marqueeRaf.current = requestAnimationFrame(() =>
+          applyMarquee(ev.clientX, ev.clientY),
+        );
+      };
+      const handleScroll = () => {
+        if (active && !isTouch) cacheTiles();
+      };
+      const handleUp = () => {
+        window.removeEventListener("pointermove", handleMove);
+        window.removeEventListener("pointerup", handleUp);
+        window.removeEventListener("scroll", handleScroll, true);
+        cancelAnimationFrame(marqueeRaf.current);
+        document.body.style.userSelect = "";
+        if (marqueeRef.current) marqueeRef.current.style.display = "none";
+        // Plain click on blank background (no marquee drawn) clears the
+        // selection, like clicking the desktop on an OS.
+        if (!active) {
+          useLibrarySelectionStore.getState().clear();
+        }
+      };
+      window.addEventListener("pointermove", handleMove);
+      window.addEventListener("pointerup", handleUp);
+      window.addEventListener("scroll", handleScroll, true);
     },
-    [requestFolderDrop, clearBulkSelection],
+    [lightboxOpen],
   );
 
   const handleBulkDelete = useCallback(() => {
-    const ids = Array.from(bulkSelectedIdsRef.current);
+    const ids = Array.from(useLibrarySelectionStore.getState().ids);
     if (ids.length === 0) return;
     showActionReminder({
       reminderType: "default",
@@ -434,13 +554,13 @@ export default function Library() {
           await Promise.allSettled(ids.map((id) => deleteLibraryMedia(id)));
           const idSet = new Set(ids);
           setAllItems((prev) => prev.filter((it) => !idSet.has(it.id)));
-          clearBulkSelection();
+          useLibrarySelectionStore.getState().clear();
         } finally {
           isActionReminderOpen.value = false;
         }
       },
     });
-  }, [clearBulkSelection]);
+  }, []);
 
   const groupedItems = useMemo(() => groupByDate(displayItems), [displayItems]);
   const flatItems = useMemo(
@@ -463,6 +583,7 @@ export default function Library() {
 
   const handleItemDeleted = useCallback((id: string) => {
     setAllItems((prev) => prev.filter((item) => item.id !== id));
+    useLibrarySelectionStore.getState().removeIds([id]);
     // Also drop it from any cached folder views (e.g. deleted via the lightbox).
     useLibraryFoldersStore.setState((s) => {
       const next: Record<string, GalleryItem[]> = {};
@@ -473,17 +594,15 @@ export default function Library() {
     });
   }, []);
 
-  const handleCardClick = useCallback(
-    (item: GalleryItem) => {
-      if (bulkSelectionMode) {
-        toggleBulkSelect(item.id);
-        return;
-      }
-      setLightboxItem(item);
-      setLightboxOpen(true);
-    },
-    [bulkSelectionMode, toggleBulkSelect],
-  );
+  const handleCardClick = useCallback((item: GalleryItem) => {
+    const selection = useLibrarySelectionStore.getState();
+    if (selection.ids.size > 0) {
+      selection.toggle(item.id);
+      return;
+    }
+    setLightboxItem(item);
+    setLightboxOpen(true);
+  }, []);
 
   const handleImageError = useCallback(
     (e: React.SyntheticEvent<HTMLImageElement>) => {
@@ -587,43 +706,40 @@ export default function Library() {
     currentSubfolders.length === 0 &&
     !folderContentLoading;
 
-  // Shared date-grouped media grid (source items differ per mode via displayItems).
+  // Shared date-grouped media grid (source items differ per mode via
+  // displayItems). Each date group is virtualized: groups outside the
+  // viewport (+800px) unmount behind a measured-height placeholder, keeping
+  // scrolling smooth for large libraries (same component the desktop modal uses).
   const mediaGrid = (
     <>
-      {groupedItems.map(([date, dateItems]) => (
-        <div key={date}>
+      {groupedItems.map(([date, dateItems], groupIndex) => (
+        <LazyDateGroup
+          key={date}
+          eager={groupIndex < 2}
+          itemCount={dateItems.length}
+          gridColumns={4}
+          scrollRoot={null}
+        >
           <h3 className="text-sm font-medium text-white/50 mb-2">{date}</h3>
           <div className={GRID_CLASS}>
             {dateItems.map((item) => (
-              <GalleryDraggableItem
+              <LibraryTile
                 key={item.id}
                 item={item}
-                mode="view"
                 activeFilter={activeFilter}
-                selected={false}
-                onClick={() => handleCardClick(item)}
-                onImageError={handleImageError}
-                imageFit="cover"
-                onDeleted={handleItemDeleted}
-                onDelete={deleteLibraryMedia}
+                activeFolderId={activeFolderId}
                 folders={folders}
+                onCardClick={handleCardClick}
+                onImageError={handleImageError}
+                onDeleted={handleItemDeleted}
                 onAddToFolder={requestFolderDrop}
-                onCreateFolderFromMenu={() =>
-                  openNewFolderModal(activeFolderId)
-                }
-                onRemoveFromFolder={
-                  activeFolderId
-                    ? (ids) => removeMediaFromFolder(ids, activeFolderId)
-                    : undefined
-                }
-                bulkSelected={bulkSelectedIds.has(item.id)}
-                bulkSelectionMode={bulkSelectionMode}
-                onBulkSelectToggle={() => toggleBulkSelect(item.id)}
+                onNewFolder={openNewFolderModal}
+                onRemoveFromFolder={removeMediaFromFolder}
                 getBulkDragItems={getBulkDragItems}
               />
             ))}
           </div>
-        </div>
+        </LazyDateGroup>
       ))}
     </>
   );
@@ -632,10 +748,14 @@ export default function Library() {
     <div
       ref={rootRef}
       className="relative min-h-full w-full bg-[#101014] pb-8 px-3 sm:px-4 md:px-8 lg:px-12"
+      onPointerDown={handleMarqueePointerDown}
     >
       <div className="mx-auto max-w-[1600px]">
         {/* Header — sticky below navbar */}
-        <div className="sticky top-0 z-50 -mx-3 sm:-mx-4 md:-mx-8 lg:-mx-12 px-3 sm:px-4 md:px-8 lg:px-12 pb-3 pt-3 bg-[#101014] mb-6">
+        <div
+          data-no-marquee
+          className="sticky top-0 z-50 -mx-3 sm:-mx-4 md:-mx-8 lg:-mx-12 px-3 sm:px-4 md:px-8 lg:px-12 pb-3 pt-3 bg-[#101014] mb-4 sm:mb-6"
+        >
           <div className="flex flex-col gap-6">
             {/* Tabs + actions */}
             <div className="flex items-center justify-between gap-3">
@@ -904,100 +1024,24 @@ export default function Library() {
           )}
         </div>
 
-        {/* Bulk selection bar */}
-        {bulkSelectionMode && (
-          <div className="sticky bottom-20 sm:bottom-4 z-30 mx-auto mt-4 flex w-fit items-center gap-2 rounded-full border border-ui-panel-border bg-ui-panel/95 px-2.5 py-2 shadow-xl backdrop-blur">
-            <div className="hidden sm:flex pl-1">
-              {bulkSelectedItems.slice(0, 4).map((si) => (
-                <BulkThumb key={si.id} item={si} />
-              ))}
-              {bulkSelectedItems.length > 4 && (
-                <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded border-2 border-ui-panel bg-black/20">
-                  <span className="text-[11px] text-white/70">
-                    +{bulkSelectedItems.length - 4}
-                  </span>
-                </div>
-              )}
-            </div>
-            <span className="px-1 text-sm font-medium text-white/80">
-              {bulkSelectedIds.size} selected
-            </span>
+        {/* Marquee selection rectangle — always mounted, positioned imperatively
+            during the drag so sweeping doesn't re-render the page */}
+        <div
+          ref={marqueeRef}
+          style={{ display: "none" }}
+          className="pointer-events-none fixed z-40 rounded-sm border border-primary/60 bg-primary/10"
+        />
 
-            {/* Add to folder */}
-            <div className="relative">
-              <button
-                type="button"
-                onClick={() => setBulkFolderPopoverOpen((v) => !v)}
-                className="flex items-center gap-2 rounded-full bg-ui-controls/60 px-3 py-1.5 text-sm font-medium text-white hover:bg-ui-controls/90 transition-colors"
-              >
-                <FontAwesomeIcon icon={faFolderPlus} className="text-xs" />
-                Add to folder
-              </button>
-              {bulkFolderPopoverOpen && (
-                <>
-                  <div
-                    className="fixed inset-0 z-[59]"
-                    onClick={() => setBulkFolderPopoverOpen(false)}
-                  />
-                  <div className="absolute bottom-full right-0 z-[60] mb-2 max-h-72 w-56 overflow-y-auto rounded-lg border border-ui-panel-border bg-ui-panel p-2 shadow-xl">
-                    <div className="px-2 py-1 text-[11px] font-semibold uppercase tracking-wider text-white/40">
-                      Folders
-                    </div>
-                    {folders.length === 0 ? (
-                      <div className="px-2 py-1.5 text-xs italic text-white/30">
-                        No folders yet
-                      </div>
-                    ) : (
-                      folders.map((folder) => (
-                        <button
-                          key={folder.id}
-                          type="button"
-                          onClick={() => handleBulkAddToFolder(folder.id)}
-                          className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-sm text-white hover:bg-ui-controls/50 transition-colors"
-                        >
-                          <FontAwesomeIcon
-                            icon={faFolder}
-                            className="text-xs text-primary"
-                          />
-                          <span className="truncate">{folder.name}</span>
-                        </button>
-                      ))
-                    )}
-                    <div className="mx-1.5 my-1 border-t border-ui-panel-border" />
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setBulkFolderPopoverOpen(false);
-                        openNewFolderModal(activeFolderId);
-                      }}
-                      className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-sm text-white/70 hover:bg-ui-controls/50 transition-colors"
-                    >
-                      <FontAwesomeIcon icon={faPlus} className="w-4 text-xs" />
-                      <span>Create new folder</span>
-                    </button>
-                  </div>
-                </>
-              )}
-            </div>
-
-            <button
-              type="button"
-              onClick={handleBulkDelete}
-              className="flex items-center gap-2 rounded-full bg-red/90 px-3 py-1.5 text-sm font-medium text-white hover:bg-red transition-colors"
-            >
-              <FontAwesomeIcon icon={faTrashCan} className="text-xs" />
-              Delete
-            </button>
-            <button
-              type="button"
-              onClick={clearBulkSelection}
-              aria-label="Clear selection"
-              className="flex h-8 w-8 items-center justify-center rounded-full bg-ui-controls/60 text-white hover:bg-ui-controls/90 transition-colors"
-            >
-              <FontAwesomeIcon icon={faXmark} />
-            </button>
-          </div>
-        )}
+        {/* Bulk selection bar — subscribes to the selection store itself so
+            the page doesn't re-render as the selection changes */}
+        <BulkSelectionBar
+          allItems={allItems}
+          folders={folders}
+          activeFolderId={activeFolderId}
+          onAddToFolder={requestFolderDrop}
+          onDeleteSelected={handleBulkDelete}
+          onNewFolder={openNewFolderModal}
+        />
       </div>
 
       {/* Floating drag preview (multi-select count chip) */}
@@ -1132,6 +1176,230 @@ export default function Library() {
   );
 }
 
+// ── Memoized gallery tile ─────────────────────────────────────────────────────
+// Keeps the per-item closures out of the page render, and subscribes to its OWN
+// slice of the selection store: a marquee/selection commit re-renders only the
+// tiles whose checked state flipped — the page itself doesn't render at all.
+
+interface LibraryTileProps {
+  item: GalleryItem;
+  activeFilter: string;
+  activeFolderId: string | null;
+  folders: UiFolder[];
+  onCardClick: (item: GalleryItem) => void;
+  onImageError: (e: React.SyntheticEvent<HTMLImageElement>) => void;
+  onDeleted: (id: string) => void;
+  onAddToFolder: (itemIds: string[], folderId: string) => void;
+  onNewFolder: (parentId: string | null) => void;
+  onRemoveFromFolder: (itemIds: string[], folderId: string) => void;
+  getBulkDragItems: () => GalleryItem[];
+}
+
+const LibraryTile = memo(function LibraryTile({
+  item,
+  activeFilter,
+  activeFolderId,
+  folders,
+  onCardClick,
+  onImageError,
+  onDeleted,
+  onAddToFolder,
+  onNewFolder,
+  onRemoveFromFolder,
+  getBulkDragItems,
+}: LibraryTileProps) {
+  const bulkSelected = useLibrarySelectionStore((s) => s.ids.has(item.id));
+  const bulkSelectionMode = useLibrarySelectionStore((s) => s.ids.size > 0);
+  return (
+    <GalleryDraggableItem
+      item={item}
+      mode="view"
+      activeFilter={activeFilter}
+      selected={false}
+      onClick={() => onCardClick(item)}
+      onImageError={onImageError}
+      imageFit="cover"
+      onDeleted={onDeleted}
+      onDelete={deleteLibraryMedia}
+      folders={folders}
+      onAddToFolder={onAddToFolder}
+      onCreateFolderFromMenu={() => onNewFolder(activeFolderId)}
+      onRemoveFromFolder={
+        activeFolderId
+          ? (ids) => onRemoveFromFolder(ids, activeFolderId)
+          : undefined
+      }
+      bulkSelected={bulkSelected}
+      bulkSelectionMode={bulkSelectionMode}
+      onBulkSelectToggle={() =>
+        useLibrarySelectionStore.getState().toggle(item.id)
+      }
+      getBulkDragItems={getBulkDragItems}
+    />
+  );
+});
+
+// ── Bulk selection bar ────────────────────────────────────────────────────────
+// Owns its own subscription to the selection store (and the folder popover
+// state), so selection changes re-render only this small bar, never the page.
+
+interface BulkSelectionBarProps {
+  allItems: GalleryItem[];
+  folders: UiFolder[];
+  activeFolderId: string | null;
+  onAddToFolder: (itemIds: string[], folderId: string) => void;
+  onDeleteSelected: () => void;
+  onNewFolder: (parentId: string | null) => void;
+}
+
+function BulkSelectionBar({
+  allItems,
+  folders,
+  activeFolderId,
+  onAddToFolder,
+  onDeleteSelected,
+  onNewFolder,
+}: BulkSelectionBarProps) {
+  const ids = useLibrarySelectionStore((s) => s.ids);
+  const folderMediaItems = useLibraryFoldersStore((s) => s.folderMediaItems);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+
+  // Close the popover when navigating so it doesn't dangle over the new view.
+  useEffect(() => {
+    setPopoverOpen(false);
+  }, [activeFolderId]);
+
+  // Resolve selected items from everything loaded (root library + folder
+  // caches) — the selection survives navigation, so selected items may not be
+  // part of the currently displayed view.
+  const selectedItems = useMemo(() => {
+    const byId = new Map(allItems.map((it) => [it.id, it] as const));
+    for (const arr of Object.values(folderMediaItems)) {
+      for (const it of arr) {
+        if (!byId.has(it.id)) byId.set(it.id, it);
+      }
+    }
+    return Array.from(ids)
+      .map((id) => byId.get(id))
+      .filter((it): it is GalleryItem => !!it);
+  }, [allItems, folderMediaItems, ids]);
+
+  if (ids.size === 0) return null;
+  const clear = () => useLibrarySelectionStore.getState().clear();
+
+  return (
+    <div
+      data-no-marquee
+      className="fixed bottom-20 sm:bottom-4 z-30 flex w-fit -translate-x-1/2 items-center gap-2 rounded-full border border-ui-panel-border bg-ui-panel/95 px-2.5 py-2 shadow-xl backdrop-blur"
+      style={{
+        // Center within the content area (viewport minus the app sidebar).
+        left: "calc(50% + var(--ac-sidebar-offset, 0px) / 2)",
+      }}
+    >
+      <div className="hidden sm:flex pl-1">
+        {selectedItems.slice(0, 4).map((si) => (
+          <BulkThumb key={si.id} item={si} />
+        ))}
+        {selectedItems.length > 4 && (
+          <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded border-2 border-ui-panel bg-black/20">
+            <span className="text-[11px] text-white/70">
+              +{selectedItems.length - 4}
+            </span>
+          </div>
+        )}
+      </div>
+      <span className="px-1 text-sm font-medium text-white/80">
+        {ids.size} selected
+      </span>
+
+      {/* Add to folder */}
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setPopoverOpen((v) => !v)}
+          className="flex items-center gap-2 rounded-full bg-ui-controls/60 px-3 py-1.5 text-sm font-medium text-white hover:bg-ui-controls/90 transition-colors"
+        >
+          <FontAwesomeIcon icon={faFolderPlus} className="text-xs" />
+          Add to folder
+        </button>
+        {popoverOpen && (
+          <>
+            <div
+              className="fixed inset-0 z-[59]"
+              onClick={() => setPopoverOpen(false)}
+            />
+            <div className="absolute bottom-full right-0 z-[60] mb-2 max-h-72 w-56 overflow-y-auto rounded-lg border border-ui-panel-border bg-ui-panel p-2 shadow-xl">
+              <div className="px-2 py-1 text-[11px] font-semibold uppercase tracking-wider text-white/40">
+                Folders
+              </div>
+              {folders.length === 0 ? (
+                <div className="px-2 py-1.5 text-xs italic text-white/30">
+                  No folders yet
+                </div>
+              ) : (
+                folders.map((folder) => (
+                  <button
+                    key={folder.id}
+                    type="button"
+                    onClick={() => {
+                      onAddToFolder(Array.from(ids), folder.id);
+                      setPopoverOpen(false);
+                      clear();
+                    }}
+                    className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-sm text-white hover:bg-ui-controls/50 transition-colors"
+                  >
+                    <FontAwesomeIcon
+                      icon={faFolder}
+                      className={
+                        folder.colorCode ? "text-xs" : "text-xs text-primary"
+                      }
+                      style={
+                        folder.colorCode
+                          ? { color: folder.colorCode }
+                          : undefined
+                      }
+                    />
+                    <span className="truncate">{folder.name}</span>
+                  </button>
+                ))
+              )}
+              <div className="mx-1.5 my-1 border-t border-ui-panel-border" />
+              <button
+                type="button"
+                onClick={() => {
+                  setPopoverOpen(false);
+                  onNewFolder(activeFolderId);
+                }}
+                className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-sm text-white/70 hover:bg-ui-controls/50 transition-colors"
+              >
+                <FontAwesomeIcon icon={faPlus} className="w-4 text-xs" />
+                <span>Create new folder</span>
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={onDeleteSelected}
+        className="flex items-center gap-2 rounded-full bg-red/90 px-3 py-1.5 text-sm font-medium text-white hover:bg-red transition-colors"
+      >
+        <FontAwesomeIcon icon={faTrashCan} className="text-xs" />
+        Delete
+      </button>
+      <button
+        type="button"
+        onClick={clear}
+        aria-label="Clear selection"
+        className="flex h-8 w-8 items-center justify-center rounded-full bg-ui-controls/60 text-white hover:bg-ui-controls/90 transition-colors"
+      >
+        <FontAwesomeIcon icon={faXmark} />
+      </button>
+    </div>
+  );
+}
+
 // ── Bulk selection thumbnail ──────────────────────────────────────────────────
 
 function BulkThumb({ item }: { item: GalleryItem }) {
@@ -1163,4 +1431,3 @@ function BulkThumb({ item }: { item: GalleryItem }) {
     </div>
   );
 }
-

--- a/frontend/apps/artcraft-webapp/tailwind.config.js
+++ b/frontend/apps/artcraft-webapp/tailwind.config.js
@@ -37,6 +37,7 @@ module.exports = {
       white: colors.white,
       gray: colors.gray,
       black: colors.black,
+      rose: colors.rose,
       red: { ...colors.red, DEFAULT: "#D33242" },
       blue: { ...colors.blue, DEFAULT: "#2E70FF" },
       orange: colors.orange,

--- a/frontend/libs/components/gallery-modal/src/lib/GalleryDraggableItem.tsx
+++ b/frontend/libs/components/gallery-modal/src/lib/GalleryDraggableItem.tsx
@@ -188,6 +188,9 @@ export const GalleryDraggableItem: React.FC<GalleryDraggableItemProps> = ({
     // Left button only — right/middle click must not trigger the click→lightbox
     // (right-click opens the context menu via onContextMenu instead).
     if (event.button !== 0) return;
+    // No drag tracking on touch: a finger drag should scroll the page, and a
+    // tap still clicks via the button's onClick.
+    if (event.pointerType === "touch") return;
     dragStarted.current = false;
     const moveListener = (moveEvent: PointerEvent) => {
       const dx = moveEvent.pageX - event.pageX;
@@ -206,28 +209,16 @@ export const GalleryDraggableItem: React.FC<GalleryDraggableItemProps> = ({
     };
     window.addEventListener("pointermove", moveListener);
     const upListener = () => {
+      // Cleanup only — the click itself is handled once by handleButtonClick
+      // (multiple firing paths used to double-toggle bulk selection).
       window.removeEventListener("pointermove", moveListener);
       window.removeEventListener("pointerup", upListener);
-      if (!dragStarted.current) {
-        onClick();
-      }
     };
     window.addEventListener("pointerup", upListener);
   };
 
-  const handlePointerUp = (event: React.PointerEvent) => {
-    if (event.button !== 0) return; // right/middle click → context menu, not lightbox
-    if (bulkSelectionMode) return;
-    const globalDrag = galleryDnd.getDragState();
-    if (globalDrag.isDragging) return;
-    if (
-      !dragStarted.current &&
-      (mode === "select" || !disableTooltipAndBadge)
-    ) {
-      onClick();
-    }
-  };
-
+  // Single click path for the whole tile surface: open the lightbox, or toggle
+  // selection when bulk-selecting / in select mode (handled by the host's onClick).
   const handleButtonClick = (event: React.MouseEvent) => {
     if (event.button !== 0) return;
     if (dragStarted.current) return;
@@ -258,7 +249,6 @@ export const GalleryDraggableItem: React.FC<GalleryDraggableItemProps> = ({
             : "cursor-grab hover:cursor-grab active:cursor-grabbing",
       )}
       onPointerDown={handlePointerDown}
-      onPointerUp={handlePointerUp}
       onClick={handleButtonClick}
       aria-label={item.label}
     >
@@ -308,6 +298,7 @@ export const GalleryDraggableItem: React.FC<GalleryDraggableItemProps> = ({
   return (
     <div
       className="group relative w-full aspect-square"
+      data-media-id={item.id}
       onContextMenu={(e) => {
         if (mode === "select") return;
         e.preventDefault();
@@ -318,7 +309,7 @@ export const GalleryDraggableItem: React.FC<GalleryDraggableItemProps> = ({
       {/* dropdown menu */}
       {mode !== "select" && (
         <div
-          className="absolute right-2 top-2 z-30 opacity-0 group-hover:opacity-100 transition-opacity duration-75"
+          className="absolute right-2 top-2 z-30 opacity-0 group-hover:opacity-100 [@media(pointer:coarse)]:opacity-100 transition-opacity duration-75"
           onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
@@ -332,13 +323,14 @@ export const GalleryDraggableItem: React.FC<GalleryDraggableItemProps> = ({
               <FontAwesomeIcon icon={faEllipsis} className="text-base-fg" />
             }
             buttonClassName="h-7 w-7 p-0 rounded-full bg-ui-controls/60 hover:bg-ui-controls/90 text-base-fg border border-ui-controls-border"
-            panelClassName="min-w-36 p-1"
+            panelClassName="w-max min-w-44 p-1"
             closeOnUnhover
           >
             {(close) => (
               <GalleryItemMenuItems
                 item={item}
                 folders={folders}
+                onOpen={onClick}
                 onEditClicked={onEditClicked}
                 onAddToFolder={onAddToFolder}
                 onCreateFolderFromMenu={onCreateFolderFromMenu}
@@ -365,7 +357,7 @@ export const GalleryDraggableItem: React.FC<GalleryDraggableItemProps> = ({
             />
             <div
               ref={ctxPanelRef}
-              className="fixed z-[9999] min-w-44 rounded-lg border border-ui-panel-border bg-ui-panel p-1 shadow-xl"
+              className="fixed z-[9999] w-max min-w-44 rounded-lg border border-ui-panel-border bg-ui-panel p-1 shadow-xl"
               style={{ left: ctxMenu.x, top: ctxMenu.y }}
             >
               <GalleryItemMenuItems
@@ -395,7 +387,7 @@ export const GalleryDraggableItem: React.FC<GalleryDraggableItemProps> = ({
               : "border-white/60 bg-black/40 hover:border-white",
             bulkSelectionMode
               ? "opacity-100"
-              : "opacity-0 group-hover:opacity-100",
+              : "opacity-0 group-hover:opacity-100 [@media(pointer:coarse)]:opacity-100",
           )}
           onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => {

--- a/frontend/libs/components/gallery-modal/src/lib/GalleryFolderChip.tsx
+++ b/frontend/libs/components/gallery-modal/src/lib/GalleryFolderChip.tsx
@@ -9,8 +9,12 @@ interface GalleryFolderChipProps {
   /** Direct subfolder count, shown as a subtitle. */
   childCount: number;
   onOpen: (folderId: string) => void;
-  /** Opens the shared folder context menu (rename / delete / color / star / new subfolder). */
-  onContextMenu: (folderId: string, x: number, y: number) => void;
+  /**
+   * Opens the shared folder context menu (rename / delete / color / star /
+   * new subfolder). When absent (e.g. select-mode pickers) the ellipsis button
+   * is hidden and right-click does nothing.
+   */
+  onContextMenu?: (folderId: string, x: number, y: number) => void;
 }
 
 /** A folder thumbnail that removes itself on error so a fallback can show. */
@@ -50,7 +54,7 @@ export const GalleryFolderChip: React.FC<GalleryFolderChipProps> = ({
 
   const openMenuAt = (target: HTMLElement) => {
     const rect = target.getBoundingClientRect();
-    onContextMenu(folder.id, rect.right, rect.bottom);
+    onContextMenu?.(folder.id, rect.right, rect.bottom);
   };
 
   return (
@@ -60,7 +64,7 @@ export const GalleryFolderChip: React.FC<GalleryFolderChipProps> = ({
       onClick={() => onOpen(folder.id)}
       onContextMenu={(e) => {
         e.preventDefault();
-        onContextMenu(folder.id, e.clientX, e.clientY);
+        onContextMenu?.(folder.id, e.clientX, e.clientY);
       }}
       style={colorCode ? { borderColor: colorCode } : undefined}
       className={twMerge(
@@ -155,20 +159,22 @@ export const GalleryFolderChip: React.FC<GalleryFolderChipProps> = ({
         )}
       </div>
 
-      {/* Options menu */}
-      <span
-        role="button"
-        tabIndex={-1}
-        aria-label="Folder options"
-        onPointerDown={(e) => e.stopPropagation()}
-        onClick={(e) => {
-          e.stopPropagation();
-          openMenuAt(e.currentTarget as HTMLElement);
-        }}
-        className="absolute right-1.5 top-1.5 flex h-7 w-7 items-center justify-center rounded-full bg-black/40 text-white opacity-0 transition-opacity hover:bg-black/60 group-hover/chip:opacity-100"
-      >
-        <FontAwesomeIcon icon={faEllipsis} className="text-sm" />
-      </span>
+      {/* Options menu — hidden when no menu handler is wired (select mode) */}
+      {onContextMenu && (
+        <span
+          role="button"
+          tabIndex={-1}
+          aria-label="Folder options"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            openMenuAt(e.currentTarget as HTMLElement);
+          }}
+          className="absolute right-1.5 top-1.5 flex h-7 w-7 items-center justify-center rounded-full bg-black/40 text-white opacity-0 transition-opacity hover:bg-black/60 group-hover/chip:opacity-100 [@media(pointer:coarse)]:opacity-100"
+        >
+          <FontAwesomeIcon icon={faEllipsis} className="text-sm" />
+        </span>
+      )}
     </button>
   );
 };

--- a/frontend/libs/components/gallery-modal/src/lib/GalleryItemMenuItems.tsx
+++ b/frontend/libs/components/gallery-modal/src/lib/GalleryItemMenuItems.tsx
@@ -10,8 +10,15 @@ import {
   faFolder,
   faPlus,
 } from "@fortawesome/pro-solid-svg-icons";
+import { twMerge } from "tailwind-merge";
 import { GalleryItem } from "./gallery-modal";
 import { GalleryFolder } from "./GalleryDraggableItem";
+
+// Touch-first devices have no hover and narrow viewports — the folder submenu
+// expands inline (accordion) instead of flying out past the screen edge.
+const COARSE_POINTER =
+  typeof window !== "undefined" &&
+  window.matchMedia?.("(pointer: coarse)").matches === true;
 
 export interface GalleryItemMenuItemsProps {
   item: GalleryItem;
@@ -30,7 +37,7 @@ export interface GalleryItemMenuItemsProps {
 }
 
 const ROW =
-  "flex w-full items-center gap-2 px-2 py-2 rounded-md hover:bg-ui-controls/60 text-base-fg text-sm";
+  "flex w-full items-center gap-2 px-2 py-2 rounded-md hover:bg-ui-controls/60 text-base-fg text-sm whitespace-nowrap";
 
 /**
  * The gallery-tile menu body (Open / Edit / Add to Folder ▸ / Remove from
@@ -63,7 +70,13 @@ export const GalleryItemMenuItems: React.FC<GalleryItemMenuItemsProps> = ({
           }}
         >
           <FontAwesomeIcon icon={faEye} className="text-base-fg w-4" />
-          <span>Open</span>
+          <span>
+            {item.mediaClass === "video"
+              ? "View video"
+              : item.mediaClass === "dimensional"
+                ? "View 3D"
+                : "View image"}
+          </span>
         </button>
       )}
 
@@ -88,12 +101,16 @@ export const GalleryItemMenuItems: React.FC<GalleryItemMenuItemsProps> = ({
       {onAddToFolder && (
         <div
           className="relative"
-          onMouseEnter={() => setFolderSubmenuOpen(true)}
-          onMouseLeave={() => setFolderSubmenuOpen(false)}
+          onMouseEnter={
+            COARSE_POINTER ? undefined : () => setFolderSubmenuOpen(true)
+          }
+          onMouseLeave={
+            COARSE_POINTER ? undefined : () => setFolderSubmenuOpen(false)
+          }
         >
           <button
             type="button"
-            className="flex w-full items-center justify-between gap-2 px-2 py-2 rounded-md hover:bg-ui-controls/60 text-base-fg text-sm"
+            className="flex w-full items-center justify-between gap-2 px-2 py-2 rounded-md hover:bg-ui-controls/60 text-base-fg text-sm whitespace-nowrap"
             onClick={(e) => {
               e.stopPropagation();
               setFolderSubmenuOpen((v) => !v);
@@ -105,51 +122,44 @@ export const GalleryItemMenuItems: React.FC<GalleryItemMenuItemsProps> = ({
             </div>
             <FontAwesomeIcon
               icon={faChevronRight}
-              className="text-[10px] text-base-fg/50"
+              className={twMerge(
+                "text-[10px] text-base-fg/50 transition-transform",
+                COARSE_POINTER && folderSubmenuOpen && "rotate-90",
+              )}
             />
           </button>
-          {folderSubmenuOpen && (
-            <div className="absolute left-full top-0 -ml-1 pl-2 z-50">
-              <div className="max-h-64 overflow-y-auto min-w-36 rounded-lg border border-ui-panel-border bg-ui-panel p-1 shadow-xl">
-                {folders.map((folder) => (
-                  <button
-                    key={folder.id}
-                    type="button"
-                    className="flex w-full items-center gap-2 px-2 py-1.5 rounded-md hover:bg-ui-controls/60 text-base-fg text-sm"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onAddToFolder([item.id], folder.id);
+          {folderSubmenuOpen &&
+            (COARSE_POINTER ? (
+              // Touch: expand inline (accordion) — a fly-out would overflow
+              // the screen edge on narrow viewports.
+              <div className="mb-1 max-h-48 overflow-y-auto rounded-md bg-ui-controls/20 p-1">
+                <FolderList
+                  item={item}
+                  folders={folders}
+                  onAddToFolder={onAddToFolder}
+                  onCreateFolderFromMenu={onCreateFolderFromMenu}
+                  closeAll={() => {
+                    setFolderSubmenuOpen(false);
+                    close();
+                  }}
+                />
+              </div>
+            ) : (
+              <div className="absolute left-full top-0 -ml-1 pl-2 z-50">
+                <div className="max-h-64 overflow-y-auto w-max min-w-36 rounded-lg border border-ui-panel-border bg-ui-panel p-1 shadow-xl">
+                  <FolderList
+                    item={item}
+                    folders={folders}
+                    onAddToFolder={onAddToFolder}
+                    onCreateFolderFromMenu={onCreateFolderFromMenu}
+                    closeAll={() => {
                       setFolderSubmenuOpen(false);
                       close();
                     }}
-                  >
-                    <FontAwesomeIcon
-                      icon={faFolder}
-                      className={folder.colorCode ? "text-xs" : "text-primary text-xs"}
-                      style={folder.colorCode ? { color: folder.colorCode } : undefined}
-                    />
-                    <span className="truncate">{folder.name}</span>
-                  </button>
-                ))}
-                {folders.length > 0 && (
-                  <div className="mx-1.5 my-1 border-t border-ui-panel-border" />
-                )}
-                <button
-                  type="button"
-                  className="flex w-full items-center gap-2 px-2 py-1.5 rounded-md hover:bg-ui-controls/60 text-base-fg/70 text-sm"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setFolderSubmenuOpen(false);
-                    close();
-                    onCreateFolderFromMenu?.();
-                  }}
-                >
-                  <FontAwesomeIcon icon={faPlus} className="text-xs w-4" />
-                  <span>New Folder</span>
-                </button>
+                  />
+                </div>
               </div>
-            </div>
-          )}
+            ))}
         </div>
       )}
 
@@ -171,7 +181,7 @@ export const GalleryItemMenuItems: React.FC<GalleryItemMenuItemsProps> = ({
       {onDelete && (
         <button
           type="button"
-          className="flex w-full items-center gap-2 px-2 py-2 rounded-md hover:bg-ui-controls/60 text-sm"
+          className="flex w-full items-center gap-2 px-2 py-2 rounded-md hover:bg-ui-controls/60 text-sm whitespace-nowrap"
           onClick={(e) => {
             e.stopPropagation();
             close();
@@ -185,3 +195,55 @@ export const GalleryItemMenuItems: React.FC<GalleryItemMenuItemsProps> = ({
     </div>
   );
 };
+
+/** The folder target list inside "Add to Folder" (shared by the fly-out and the inline accordion). */
+const FolderList = ({
+  item,
+  folders,
+  onAddToFolder,
+  onCreateFolderFromMenu,
+  closeAll,
+}: {
+  item: GalleryItem;
+  folders: GalleryFolder[];
+  onAddToFolder?: (itemIds: string[], folderId: string) => void;
+  onCreateFolderFromMenu?: () => void;
+  closeAll: () => void;
+}) => (
+  <>
+    {folders.map((folder) => (
+      <button
+        key={folder.id}
+        type="button"
+        className="flex w-full items-center gap-2 px-2 py-1.5 rounded-md hover:bg-ui-controls/60 text-base-fg text-sm"
+        onClick={(e) => {
+          e.stopPropagation();
+          onAddToFolder?.([item.id], folder.id);
+          closeAll();
+        }}
+      >
+        <FontAwesomeIcon
+          icon={faFolder}
+          className={folder.colorCode ? "text-xs" : "text-primary text-xs"}
+          style={folder.colorCode ? { color: folder.colorCode } : undefined}
+        />
+        <span className="truncate">{folder.name}</span>
+      </button>
+    ))}
+    {folders.length > 0 && (
+      <div className="mx-1.5 my-1 border-t border-ui-panel-border" />
+    )}
+    <button
+      type="button"
+      className="flex w-full items-center gap-2 px-2 py-1.5 rounded-md hover:bg-ui-controls/60 text-base-fg/70 text-sm whitespace-nowrap"
+      onClick={(e) => {
+        e.stopPropagation();
+        closeAll();
+        onCreateFolderFromMenu?.();
+      }}
+    >
+      <FontAwesomeIcon icon={faPlus} className="text-xs w-4" />
+      <span>New Folder</span>
+    </button>
+  </>
+);

--- a/frontend/libs/components/gallery-modal/src/lib/gallery-modal.tsx
+++ b/frontend/libs/components/gallery-modal/src/lib/gallery-modal.tsx
@@ -153,7 +153,7 @@ const SkeletonGrid = ({ columns }: { columns: number }) => {
 // and unmounts them when they scroll beyond that range. Measured heights are
 // used for placeholders so scroll position stays rock-solid.
 
-interface LazyDateGroupProps {
+export interface LazyDateGroupProps {
   /** If true the group renders on mount (use for first N visible groups). */
   eager: boolean;
   /** Estimated item count for placeholder height calculation. */
@@ -165,7 +165,7 @@ interface LazyDateGroupProps {
   children: React.ReactNode;
 }
 
-const LazyDateGroup = React.memo(
+export const LazyDateGroup = React.memo(
   ({
     eager,
     itemCount,
@@ -1828,8 +1828,11 @@ export const GalleryModal = React.memo(
                 folder={folder}
                 childCount={folderChildCount(folder.id)}
                 onOpen={handleOpenFolder}
-                onContextMenu={(folderId, x, y) =>
-                  setContextMenu({ folderId, x, y })
+                // Folder management is view-mode only; the select picker just browses.
+                onContextMenu={
+                  mode === "view"
+                    ? (folderId, x, y) => setContextMenu({ folderId, x, y })
+                    : undefined
                 }
               />
             ))}


### PR DESCRIPTION
…perf

- Add desktop-style marquee drag selection on the webapp library: drag on blank space to select covered tiles, click blank space to deselect all
- Multi-select: clicking anywhere on a tile toggles it (fixes a double-fire that cancelled the toggle so only the checkbox worked); selection persists across tabs and folder navigation
- Gallery item menus show "View image" / "View video" / "View 3D" above Add to Folder; menu panels size to content so labels no longer wrap
- Mobile/touch: no tile dragging or marquee (finger drags scroll), checkbox and menu buttons always visible (no hover on touch), and the Add to Folder submenu expands inline as an accordion instead of overflowing the screen
- Select-mode gallery modal: folder cards hide the options menu and ignore right-click (picker is browse-only)
- Perf: bulk selection moved to a module store with per-tile subscriptions so selection changes re-render only flipped tiles, never the page; marquee rectangle is positioned imperatively with cached tile rects and commits only when coverage changes; webapp date groups virtualized via the shared LazyDateGroup for smooth scrolling on large libraries
- Bulk selection bar extracted to its own component, fixed to the viewport bottom and centered within the content area