### PR TITLE
Webapp: seed new folders with selection + marquee selection fixes

### DIFF
--- a/frontend/apps/artcraft-webapp/src/pages/library/library-folders-store.ts
+++ b/frontend/apps/artcraft-webapp/src/pages/library/library-folders-store.ts
@@ -78,14 +78,23 @@ interface LibraryFoldersState {
   /** Whether the open folder has more media pages to load. */
   folderHasMore: Record<string, boolean>;
   // Dialog state — rendered by the library page, triggered from sidebar or page.
-  newFolderModal: { open: boolean; parentId: string | null };
+  // `addItemIds` holds the items to drop into the folder once it's created
+  // (set when opened from the bulk "Add to folder" flow; empty otherwise).
+  newFolderModal: {
+    open: boolean;
+    parentId: string | null;
+    addItemIds: string[];
+  };
   renameTarget: string | null;
   contextMenu: { folderId: string; x: number; y: number } | null;
 
   loadFolders: () => Promise<void>;
   setActiveFolder: (id: string | null) => void;
   loadFolderMedia: (folderId: string, reset?: boolean) => Promise<void>;
-  createFolder: (name: string, parentId: string | null) => Promise<void>;
+  createFolder: (
+    name: string,
+    parentId: string | null,
+  ) => Promise<UiFolder | null>;
   renameFolder: (folderId: string, name: string) => Promise<void>;
   setFolderStar: (folderId: string, hasStar: boolean) => Promise<void>;
   setFolderColor: (folderId: string, colorCode: string | null) => Promise<void>;
@@ -105,7 +114,7 @@ interface LibraryFoldersState {
     itemIds: string[],
     folderId: string,
   ) => Promise<void>;
-  openNewFolderModal: (parentId: string | null) => void;
+  openNewFolderModal: (parentId: string | null, addItemIds?: string[]) => void;
   closeNewFolderModal: () => void;
   setRenameTarget: (folderId: string | null) => void;
   setContextMenu: (
@@ -242,7 +251,7 @@ export const useLibraryFoldersStore = create<LibraryFoldersState>(
     folderContentLoading: false,
     folderLoadingMore: false,
     folderHasMore: {},
-    newFolderModal: { open: false, parentId: null },
+    newFolderModal: { open: false, parentId: null, addItemIds: [] },
     renameTarget: null,
     contextMenu: null,
 
@@ -319,19 +328,22 @@ export const useLibraryFoldersStore = create<LibraryFoldersState>(
 
     createFolder: async (name, parentId) => {
       const trimmed = name.trim();
-      if (!trimmed) return;
+      if (!trimmed) return null;
       try {
         const res = await foldersApi.CreateFolder({
           name: trimmed,
           maybe_parent_folder_token: parentId,
         });
         if (res.success && res.data) {
-          set((s) => ({ folders: [...s.folders, mapFolder(res.data!)] }));
-        } else {
-          toast.error(res.errorMessage || "Failed to create folder.");
+          const created = mapFolder(res.data);
+          set((s) => ({ folders: [...s.folders, created] }));
+          return created;
         }
+        toast.error(res.errorMessage || "Failed to create folder.");
+        return null;
       } catch (err) {
         toast.error(`Failed to create folder: ${errMsg(err)}`);
+        return null;
       }
     },
 
@@ -543,10 +555,13 @@ export const useLibraryFoldersStore = create<LibraryFoldersState>(
       }
     },
 
-    openNewFolderModal: (parentId) =>
-      set({ newFolderModal: { open: true, parentId }, contextMenu: null }),
+    openNewFolderModal: (parentId, addItemIds = []) =>
+      set({
+        newFolderModal: { open: true, parentId, addItemIds },
+        contextMenu: null,
+      }),
     closeNewFolderModal: () =>
-      set({ newFolderModal: { open: false, parentId: null } }),
+      set({ newFolderModal: { open: false, parentId: null, addItemIds: [] } }),
     setRenameTarget: (folderId) => set({ renameTarget: folderId, contextMenu: null }),
     setContextMenu: (menu) => set({ contextMenu: menu }),
   }),

--- a/frontend/apps/artcraft-webapp/src/pages/library/library.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/library/library.tsx
@@ -402,6 +402,10 @@ export default function Library() {
       ) {
         return;
       }
+      // Blank-background press: suppress the browser's native text-selection /
+      // focus default so it can't hijack the marquee drag (the cause of the
+      // drag "dying" once the viewport fills with content after scrolling).
+      e.preventDefault();
 
       const startX = e.clientX;
       const startY = e.clientY;
@@ -412,8 +416,21 @@ export default function Library() {
       let applied = base;
       let active = false;
 
-      // Tile rects are stable during the drag (no auto-scroll); cache once and
-      // refresh only if something scrolls mid-drag.
+      // Edge auto-scroll runs the list under a held cursor, so tile rects move
+      // on screen — read them in viewport space and re-cache on every scroll.
+      const scroller = getScrollParent(rootRef.current);
+      const readScrollTop = () =>
+        scroller ? scroller.scrollTop : window.scrollY;
+      const readScrollLeft = () =>
+        scroller ? scroller.scrollLeft : window.scrollX;
+      // The anchor is pinned in content space; scrolling shifts it on screen,
+      // so compensate by the scroll delta since the drag began.
+      const startScrollTop = readScrollTop();
+      const startScrollLeft = readScrollLeft();
+      let lastCx = startX;
+      let lastCy = startY;
+      let edgeRaf = 0;
+
       let tiles: {
         id: string;
         left: number;
@@ -441,21 +458,40 @@ export default function Library() {
       if (!isTouch) cacheTiles();
 
       const applyMarquee = (cx: number, cy: number) => {
-        const left = Math.min(startX, cx);
-        const top = Math.min(startY, cy);
-        const width = Math.abs(cx - startX);
-        const height = Math.abs(cy - startY);
-        const box = marqueeRef.current;
-        if (box) {
-          box.style.display = "block";
-          box.style.left = `${left}px`;
-          box.style.top = `${top}px`;
-          box.style.width = `${width}px`;
-          box.style.height = `${height}px`;
-        }
+        // Compensate the anchor for scrolling since drag start so the rectangle
+        // keeps growing in content space, not viewport space.
+        const ax = startX - (readScrollLeft() - startScrollLeft);
+        const ay = startY - (readScrollTop() - startScrollTop);
+        const left = Math.min(ax, cx);
+        const top = Math.min(ay, cy);
+        const width = Math.abs(cx - ax);
+        const height = Math.abs(cy - ay);
         const right = left + width;
         const bottom = top + height;
+        const box = marqueeRef.current;
+        if (box) {
+          // Clamp the *visible* rectangle to the scroll viewport so it never
+          // paints over the top bar / breadcrumb chrome above the gallery.
+          // Selection math below still uses the unclamped rect, so tiles
+          // scrolled above the fold stay selected.
+          const vr = scroller?.getBoundingClientRect();
+          const vTop = vr ? vr.top : 0;
+          const vBottom = vr ? vr.bottom : window.innerHeight;
+          const dispTop = Math.max(top, vTop);
+          const dispBottom = Math.min(bottom, vBottom);
+          box.style.display = "block";
+          box.style.left = `${left}px`;
+          box.style.top = `${dispTop}px`;
+          box.style.width = `${width}px`;
+          box.style.height = `${Math.max(0, dispBottom - dispTop)}px`;
+        }
+        const mounted = new Set(tiles.map((t) => t.id));
         const next = new Set(base);
+        // Tiles swept over earlier may have unmounted (virtualized list) once
+        // scrolled far away — keep them selected since we can't re-test them.
+        for (const id of applied) {
+          if (!base.has(id) && !mounted.has(id)) next.add(id);
+        }
         for (const t of tiles) {
           if (
             t.left < right &&
@@ -482,6 +518,39 @@ export default function Library() {
         }
       };
 
+      // Auto-scroll while the cursor sits within EDGE px of the viewport's top
+      // or bottom; speed ramps up nearer the edge. Self-perpetuating via rAF
+      // until the cursor leaves the zone or the drag ends.
+      const EDGE = 64;
+      const MAX_SPEED = 24;
+      const edgeBounds = () => {
+        if (scroller) {
+          const r = scroller.getBoundingClientRect();
+          return { top: r.top, bottom: r.bottom };
+        }
+        return { top: 0, bottom: window.innerHeight };
+      };
+      const autoScrollTick = () => {
+        edgeRaf = 0;
+        if (!active || isTouch) return;
+        const { top, bottom } = edgeBounds();
+        let dy = 0;
+        if (lastCy < top + EDGE) {
+          dy = -Math.min(MAX_SPEED, Math.ceil((top + EDGE - lastCy) / 3));
+        } else if (lastCy > bottom - EDGE) {
+          dy = Math.min(MAX_SPEED, Math.ceil((lastCy - (bottom - EDGE)) / 3));
+        }
+        if (dy === 0) return;
+        if (scroller) scroller.scrollTop += dy;
+        else window.scrollBy(0, dy);
+        cacheTiles();
+        applyMarquee(lastCx, lastCy);
+        edgeRaf = requestAnimationFrame(autoScrollTick);
+      };
+      const ensureAutoScroll = () => {
+        if (!edgeRaf) edgeRaf = requestAnimationFrame(autoScrollTick);
+      };
+
       const handleMove = (ev: PointerEvent) => {
         if (isTouch) {
           // Track movement only so a scroll gesture doesn't count as a
@@ -505,19 +574,26 @@ export default function Library() {
           active = true;
           document.body.style.userSelect = "none";
         }
+        lastCx = ev.clientX;
+        lastCy = ev.clientY;
+        ensureAutoScroll();
         cancelAnimationFrame(marqueeRaf.current);
         marqueeRaf.current = requestAnimationFrame(() =>
           applyMarquee(ev.clientX, ev.clientY),
         );
       };
       const handleScroll = () => {
-        if (active && !isTouch) cacheTiles();
+        if (active && !isTouch) {
+          cacheTiles();
+          applyMarquee(lastCx, lastCy);
+        }
       };
       const handleUp = () => {
         window.removeEventListener("pointermove", handleMove);
         window.removeEventListener("pointerup", handleUp);
         window.removeEventListener("scroll", handleScroll, true);
         cancelAnimationFrame(marqueeRaf.current);
+        cancelAnimationFrame(edgeRaf);
         document.body.style.userSelect = "";
         if (marqueeRef.current) marqueeRef.current.style.display = "none";
         // Plain click on blank background (no marquee drawn) clears the
@@ -622,9 +698,20 @@ export default function Library() {
   }, [loadItems]);
 
   // ── Folder dialog handlers ────────────────────────────────────────────────
-  const submitNewFolder = (name: string) => {
-    createFolder(name, newFolderModal.parentId);
+  const submitNewFolder = async (name: string) => {
+    // Capture before closing — `closeNewFolderModal` resets these fields.
+    const { parentId, addItemIds } = newFolderModal;
     closeNewFolderModal();
+    const folder = await createFolder(name, parentId);
+    if (folder && addItemIds.length > 0) {
+      // The selection can span the root library and folder caches, so resolve
+      // known items from both (incomplete `known` only weakens the optimistic
+      // preview — the server add still uses the ids and reconciles on open).
+      const fmi = useLibraryFoldersStore.getState().folderMediaItems;
+      const known = [...allItems, ...Object.values(fmi).flat()];
+      addMediaToFolder(addItemIds, folder.id, known);
+      useLibrarySelectionStore.getState().clear();
+    }
   };
 
   const startRename = (folderId: string) => setRenameTarget(folderId);
@@ -747,7 +834,16 @@ export default function Library() {
   return (
     <div
       ref={rootRef}
-      className="relative min-h-full w-full bg-[#101014] pb-8 px-3 sm:px-4 md:px-8 lg:px-12"
+      // `shrink-0` is critical: the scroll parent (`SidebarInset`) is a flex
+      // column, so without it the flex algorithm shrinks this box down to one
+      // viewport while the tall grid overflows below it — leaving the lower
+      // page outside this element, so the marquee handler (and its padding
+      // gutters) never receive pointer events there. `min-h-full` then only
+      // fills the background when content is shorter than the viewport.
+      // `select-none` blocks the blue text/image highlight when sweeping a
+      // marquee or fat-fingering a click; native selection would otherwise also
+      // hijack the drag. Form fields opt back in so dialog inputs stay editable.
+      className="relative min-h-full w-full shrink-0 select-none [&_input]:select-text [&_textarea]:select-text bg-[#101014] pb-8 px-3 sm:px-4 md:px-8 lg:px-12"
       onPointerDown={handleMarqueePointerDown}
     >
       <div className="mx-auto max-w-[1600px]">
@@ -1249,7 +1345,7 @@ interface BulkSelectionBarProps {
   activeFolderId: string | null;
   onAddToFolder: (itemIds: string[], folderId: string) => void;
   onDeleteSelected: () => void;
-  onNewFolder: (parentId: string | null) => void;
+  onNewFolder: (parentId: string | null, addItemIds?: string[]) => void;
 }
 
 function BulkSelectionBar({
@@ -1368,7 +1464,7 @@ function BulkSelectionBar({
                 type="button"
                 onClick={() => {
                   setPopoverOpen(false);
-                  onNewFolder(activeFolderId);
+                  onNewFolder(activeFolderId, Array.from(ids));
                 }}
                 className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-sm text-white/70 hover:bg-ui-controls/50 transition-colors"
               >

--- a/frontend/libs/components/gallery-modal/src/lib/gallery-modal.tsx
+++ b/frontend/libs/components/gallery-modal/src/lib/gallery-modal.tsx
@@ -562,6 +562,9 @@ export const GalleryModal = React.memo(
     const [newFolderParentId, setNewFolderParentId] = useState<string | null>(
       null,
     );
+    // Items to drop into the folder once it's created (set when the new-folder
+    // modal is opened from the bulk "Add to folder" flow; empty otherwise).
+    const [newFolderItemIds, setNewFolderItemIds] = useState<string[]>([]);
 
     // Active folder view. Resolved media items are cached per folder so
     // reopening a folder shows instantly while a fresh fetch runs in the background.
@@ -1195,20 +1198,35 @@ export const GalleryModal = React.memo(
       [foldersApi],
     );
 
-    // Folder creation — nests under `newFolderParentId` (null = root).
+    // `handleAddToFolder` is defined further down; reach it through a ref so the
+    // earlier `handleCreateFolder` can add the just-created folder's seed items.
+    const addToFolderRef = useRef<
+      ((itemIds: string[], folderId: string) => Promise<void>) | null
+    >(null);
+
+    // Folder creation — nests under `newFolderParentId` (null = root). When opened
+    // from the bulk "Add to folder" flow, `newFolderItemIds` holds the selected
+    // items, which are dropped into the new folder right after it's created.
     const handleCreateFolder = useCallback(
       async (rawName: string) => {
         const name = rawName.trim();
         if (!name) return;
         const parentId = newFolderParentId;
+        const seedItemIds = newFolderItemIds;
         setNewFolderModalOpen(false);
+        setNewFolderItemIds([]);
         try {
           const res = await foldersApi.CreateFolder({
             name,
             maybe_parent_folder_token: parentId,
           });
           if (res.success && res.data) {
-            setFolders((prev) => [...prev, mapFolder(res.data!)]);
+            const created = mapFolder(res.data);
+            setFolders((prev) => [...prev, created]);
+            if (seedItemIds.length > 0) {
+              await addToFolderRef.current?.(seedItemIds, created.id);
+              setBulkSelectedIds(new Set());
+            }
           } else {
             toast.error(res.errorMessage || "Failed to create folder.");
           }
@@ -1218,16 +1236,17 @@ export const GalleryModal = React.memo(
           );
         }
       },
-      [newFolderParentId, foldersApi, mapFolder],
+      [newFolderParentId, newFolderItemIds, foldersApi, mapFolder],
     );
 
     // Open the new-folder modal. `parentId` undefined → create in the folder
     // currently being viewed; pass `null` to force a root folder.
     const handleOpenNewFolderModal = useCallback(
-      (parentId?: string | null) => {
+      (parentId?: string | null, seedItemIds?: string[]) => {
         setNewFolderParentId(
           parentId !== undefined ? parentId : activeFolderId,
         );
+        setNewFolderItemIds(seedItemIds ?? []);
         setNewFolderModalOpen(true);
       },
       [activeFolderId],
@@ -1507,6 +1526,8 @@ export const GalleryModal = React.memo(
       },
       [resolveItems, bumpFolderCollage, folders, foldersApi],
     );
+    // Expose to `handleCreateFolder` (defined above) for the new-folder-with-items flow.
+    addToFolderRef.current = handleAddToFolder;
 
     // Move media from one folder to another (atomic). Drops from source, adds to target.
     const handleMoveMedia = useCallback(
@@ -2502,7 +2523,10 @@ export const GalleryModal = React.memo(
               initialValue="New Folder"
               confirmLabel="Create"
               onConfirm={handleCreateFolder}
-              onClose={() => setNewFolderModalOpen(false)}
+              onClose={() => {
+                setNewFolderModalOpen(false);
+                setNewFolderItemIds([]);
+              }}
             />
 
             {/* ── Rename Folder dialog (sidebar context menu) ── */}
@@ -2604,8 +2628,9 @@ export const GalleryModal = React.memo(
                             type="button"
                             className="flex w-full items-center gap-2.5 px-2 py-1.5 rounded-md hover:bg-ui-controls/50 text-sm text-base-fg/70 transition-colors"
                             onClick={() => {
+                              const ids = Array.from(bulkSelectedIds);
                               setBulkFolderPopoverOpen(false);
-                              handleOpenNewFolderModal();
+                              handleOpenNewFolderModal(undefined, ids);
                             }}
                           >
                             <FontAwesomeIcon


### PR DESCRIPTION
- **New folder keeps selection:** "Add to folder > Create new folder" now drops
  the selected items into the folder on create instead of leaving it empty
  (webapp library + desktop gallery modal)
- **Marquee dead below the fold (main bug):** flex-column scroll parent shrank
  the page root to one viewport; presses lower down missed the handler. Fixed
  with `shrink-0` so the root spans the full scroll height
- **Edge auto-scroll:** holding a drag near the top/bottom edge scrolls the list
  so you can keep selecting past the viewport in one drag (anchor compensated for
  scroll; virtualized tiles stay selected)
- **No blue highlight:** `select-none` on the page (inputs opted back in) blocks
  accidental text/image highlighting and stops it competing with the drag
- **Rectangle no longer covers the top bar:** visible marquee box clamped to the
  gallery viewport; selection hit-testing stays unclamped