### PR TITLE
Fix: silent failures when submitting a generation (recreate "does nothing" bug)

### DIFF
--- a/frontend/apps/artcraft-webapp/src/pages/create-image/create-image.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/create-image/create-image.tsx
@@ -282,6 +282,24 @@ export default function CreateImage() {
   // Consume a pending recreate payload (set by the lightbox Recreate button)
   // and populate the promptbox fields. Does NOT trigger generation. Subscribes
   // to the store so it fires even when the user is already on this route.
+  // Warn when a recreated generation's model is missing from the current
+  // model list: selectedModel silently falls back to the default model, and
+  // the restored prompt/settings may not be valid for it. Verified in its own
+  // effect because the model list may still be loading when the recreate
+  // payload is consumed.
+  const [recreateModelIdToVerify, setRecreateModelIdToVerify] = useState<
+    string | null
+  >(null);
+  useEffect(() => {
+    if (!recreateModelIdToVerify || apiModels.length === 0) return;
+    if (!apiModels.some((m) => m.model === recreateModelIdToVerify)) {
+      toast.error(
+        "The model used for this generation isn't available anymore. Using the default model instead.",
+      );
+    }
+    setRecreateModelIdToVerify(null);
+  }, [recreateModelIdToVerify, apiModels]);
+
   const pendingRecreate = useCreateImageStore((s) => s.pendingRecreate);
   useEffect(() => {
     if (!pendingRecreate) return;
@@ -294,6 +312,7 @@ export default function CreateImage() {
       ...(payload.resolution ? { resolution: payload.resolution } : {}),
       ...(payload.modelId ? { selectedModelId: payload.modelId } : {}),
     });
+    if (payload.modelId) setRecreateModelIdToVerify(payload.modelId);
   }, [pendingRecreate, setUi]);
 
   // Resume polling for pending batches
@@ -364,7 +383,13 @@ export default function CreateImage() {
       openSignupCta();
       return;
     }
-    if (!prompt.trim() || isGenerating || !selectedModel) return;
+    if (!prompt.trim() || isGenerating) return;
+    if (!selectedModel) {
+      // Models come from an API fetch; without one the submit would be a
+      // silent no-op, which reads as a dead button.
+      toast.error("Models are still loading. Try again in a moment.");
+      return;
+    }
 
     if (maxPromptLength !== undefined && prompt.length > maxPromptLength) {
       toast.error(
@@ -406,8 +431,13 @@ export default function CreateImage() {
           dismissBatch(batchId);
           openInsufficientCredits();
         } else {
+          // Always toast: batches that fail at enqueue never got a job token,
+          // so the gallery's failed-card rendering never shows them, and a
+          // silent failBatch here looks like the button did nothing.
           if (result.errorCode != null && result.errorCode >= 500) {
             toast.error(OMNI_GENERATE_OUTAGE_MESSAGE);
+          } else {
+            toast.error(result.error ?? "Failed to start generation");
           }
           failBatch(batchId, result.error ?? "Failed to start generation");
         }
@@ -434,6 +464,7 @@ export default function CreateImage() {
       );
       pollingCleanupsRef.current.set(batchId, stopPolling);
     } catch {
+      toast.error("Network error - please try again");
       failBatch(batchId, "Network error - please try again");
     } finally {
       setIsGenerating(false);

--- a/frontend/apps/artcraft-webapp/src/pages/create-image/generate-image-api.ts
+++ b/frontend/apps/artcraft-webapp/src/pages/create-image/generate-image-api.ts
@@ -1,4 +1,4 @@
-import { JobsApi, MediaFilesApi, OmniGenApi } from "@storyteller/api";
+import { HttpApiError, JobsApi, MediaFilesApi, OmniGenApi } from "@storyteller/api";
 import type { OmniGenImageRequest } from "@storyteller/api";
 import type { GeneratedImage } from "./create-image-store";
 
@@ -45,21 +45,22 @@ export async function enqueueImageGeneration(
     }
     return { success: false, error: "Generation failed" };
   } catch (err: any) {
+    // ApiManager throws HttpApiError on non-2xx responses, carrying the
+    // server's `message` so it can be shown to the user instead of a bare
+    // status code.
+    if (err instanceof HttpApiError) {
+      return {
+        success: false,
+        error: err.serverMessage ?? err.message,
+        errorCode: err.status,
+      };
+    }
     return {
       success: false,
       error: err.message ?? "Request failed",
-      errorCode: parseHttpStatusCode(err),
+      errorCode: undefined,
     };
   }
-}
-
-// Pull the HTTP status out of an ApiManager error. ApiManager throws
-// `Error("HTTP error! status: 402")` on a non-2xx response (the JSON body is
-// not surfaced), so callers can special-case codes like 402 Payment Required.
-function parseHttpStatusCode(err: unknown): number | undefined {
-  const message = err instanceof Error ? err.message : String(err);
-  const match = /status:\s*(\d+)/.exec(message);
-  return match ? Number(match[1]) : undefined;
 }
 
 // ── Poll for completion ──────────────────────────────────────────────────

--- a/frontend/apps/artcraft-webapp/src/pages/create-video/create-video.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/create-video/create-video.tsx
@@ -682,6 +682,24 @@ export default function CreateVideo() {
   // builds its label regex from `referenceImages`/`referenceVideos`/etc.) knows
   // about every `@ImageN` before the contentEditable does its DOM sync. Without
   // this ordering, only the last reference's mention would end up colored.
+  // Warn when a recreated generation's model is missing from the current
+  // model list: selectedModel silently falls back to the default model, and
+  // the restored prompt/settings may not be valid for it. Verified in its own
+  // effect because the model list may still be loading when the recreate
+  // payload is consumed.
+  const [recreateModelIdToVerify, setRecreateModelIdToVerify] = useState<
+    string | null
+  >(null);
+  useEffect(() => {
+    if (!recreateModelIdToVerify || apiModels.length === 0) return;
+    if (!apiModels.some((m) => m.model === recreateModelIdToVerify)) {
+      toast.error(
+        "The model used for this generation isn't available anymore. Using the default model instead.",
+      );
+    }
+    setRecreateModelIdToVerify(null);
+  }, [recreateModelIdToVerify, apiModels]);
+
   const pendingRecreate = useCreateVideoStore((s) => s.pendingRecreate);
   useEffect(() => {
     if (!pendingRecreate) return;
@@ -700,6 +718,7 @@ export default function CreateVideo() {
         ...(payload.inputMode ? { inputMode: payload.inputMode } : {}),
       });
     });
+    if (payload.modelId) setRecreateModelIdToVerify(payload.modelId);
 
     setUi({
       prompt: payload.prompt,
@@ -1020,12 +1039,17 @@ export default function CreateVideo() {
       );
       return;
     }
-    if (!prompt.trim() || isGeneratingRef.current || !selectedModel) {
+    if (!prompt.trim() || isGeneratingRef.current) {
       console.log("[generate-video] blocked", {
         hasPrompt: !!prompt.trim(),
         isGenerating: isGeneratingRef.current,
-        hasModel: !!selectedModel,
       });
+      return;
+    }
+    if (!selectedModel) {
+      // Models come from an API fetch; without one the submit would be a
+      // silent no-op, which reads as a dead button.
+      toast.error("Models are still loading. Try again in a moment.");
       return;
     }
     if (maxPromptLength !== undefined && prompt.length > maxPromptLength) {
@@ -1144,8 +1168,13 @@ export default function CreateVideo() {
           dismissBatch(batchId);
           openInsufficientCredits();
         } else {
+          // Always toast: batches that fail at enqueue never got a job token,
+          // so the gallery's failed-card rendering never shows them, and a
+          // silent failBatch here looks like the button did nothing.
           if (result.errorCode != null && result.errorCode >= 500) {
             toast.error(OMNI_GENERATE_OUTAGE_MESSAGE);
+          } else {
+            toast.error(result.error ?? "Failed to start generation");
           }
           failBatch(batchId, result.error ?? "Failed to start generation");
         }
@@ -1177,6 +1206,7 @@ export default function CreateVideo() {
       }
     } catch (err) {
       console.error("[generate-video] unexpected error", err);
+      toast.error("Network error - please try again");
       failBatch(batchId, "Network error - please try again");
     }
 

--- a/frontend/apps/artcraft-webapp/src/pages/create-video/generate-video-api.ts
+++ b/frontend/apps/artcraft-webapp/src/pages/create-video/generate-video-api.ts
@@ -1,4 +1,4 @@
-import { JobsApi, OmniGenApi } from "@storyteller/api";
+import { HttpApiError, JobsApi, OmniGenApi } from "@storyteller/api";
 import type { OmniGenVideoRequest } from "@storyteller/api";
 import type { GeneratedVideo } from "./create-video-store";
 
@@ -67,21 +67,22 @@ export async function enqueueVideoGeneration(
     }
     return { success: false, error: "Generation failed" };
   } catch (err: any) {
+    // ApiManager throws HttpApiError on non-2xx responses, carrying the
+    // server's `message` (e.g. "Image is required") so it can be shown to
+    // the user instead of a bare status code.
+    if (err instanceof HttpApiError) {
+      return {
+        success: false,
+        error: err.serverMessage ?? err.message,
+        errorCode: err.status,
+      };
+    }
     return {
       success: false,
       error: err.message ?? "Request failed",
-      errorCode: parseHttpStatusCode(err),
+      errorCode: undefined,
     };
   }
-}
-
-// Pull the HTTP status out of an ApiManager error. ApiManager throws
-// `Error("HTTP error! status: 402")` on a non-2xx response (the JSON body is
-// not surfaced), so callers can special-case codes like 402 Payment Required.
-function parseHttpStatusCode(err: unknown): number | undefined {
-  const message = err instanceof Error ? err.message : String(err);
-  const match = /status:\s*(\d+)/.exec(message);
-  return match ? Number(match[1]) : undefined;
 }
 
 // ── Poll for completion ──────────────────────────────────────────────────

--- a/frontend/apps/artcraft-website/src/pages/create-image/create-image.tsx
+++ b/frontend/apps/artcraft-website/src/pages/create-image/create-image.tsx
@@ -197,6 +197,24 @@ export default function CreateImage() {
   // Consume a pending recreate payload (set by the lightbox Recreate button)
   // and populate the promptbox fields. Does NOT trigger generation. Subscribes
   // to the store so it fires even when the user is already on this route.
+  // Warn when a recreated generation's model is missing from the current
+  // model list: selectedModel silently falls back to the default model, and
+  // the restored prompt/settings may not be valid for it. Verified in its own
+  // effect because the model list may still be loading when the recreate
+  // payload is consumed.
+  const [recreateModelIdToVerify, setRecreateModelIdToVerify] = useState<
+    string | null
+  >(null);
+  useEffect(() => {
+    if (!recreateModelIdToVerify || apiModels.length === 0) return;
+    if (!apiModels.some((m) => m.model === recreateModelIdToVerify)) {
+      toast.error(
+        "The model used for this generation isn't available anymore. Using the default model instead.",
+      );
+    }
+    setRecreateModelIdToVerify(null);
+  }, [recreateModelIdToVerify, apiModels]);
+
   const pendingRecreate = useCreateImageStore((s) => s.pendingRecreate);
   useEffect(() => {
     if (!pendingRecreate) return;
@@ -209,6 +227,7 @@ export default function CreateImage() {
       ...(payload.resolution ? { resolution: payload.resolution } : {}),
       ...(payload.modelId ? { selectedModelId: payload.modelId } : {}),
     });
+    if (payload.modelId) setRecreateModelIdToVerify(payload.modelId);
   }, [pendingRecreate, setUi]);
 
   // Resume polling for pending batches
@@ -280,7 +299,13 @@ export default function CreateImage() {
   );
 
   const handleGenerate = useCallback(async () => {
-    if (!prompt.trim() || isGenerating || !selectedModel) return;
+    if (!prompt.trim() || isGenerating) return;
+    if (!selectedModel) {
+      // Models come from an API fetch; without one the submit would be a
+      // silent no-op, which reads as a dead button.
+      toast.error("Models are still loading. Try again in a moment.");
+      return;
+    }
 
     if (maxPromptLength !== undefined && prompt.length > maxPromptLength) {
       toast.error(
@@ -316,6 +341,14 @@ export default function CreateImage() {
       });
 
       if (!result.success || !result.jobToken) {
+        // Always toast: batches that fail at enqueue never got a job token,
+        // so the gallery's failed-card rendering never shows them, and a
+        // silent failBatch here looks like the button did nothing.
+        if (result.errorCode === 402) {
+          toast.error("You're out of credits. Top up to keep generating.");
+        } else {
+          toast.error(result.error ?? "Failed to start generation");
+        }
         failBatch(batchId, result.error ?? "Failed to start generation");
         setIsGenerating(false);
         return;
@@ -340,6 +373,7 @@ export default function CreateImage() {
       );
       pollingCleanupsRef.current.set(batchId, stopPolling);
     } catch {
+      toast.error("Network error - please try again");
       failBatch(batchId, "Network error - please try again");
     } finally {
       setIsGenerating(false);

--- a/frontend/apps/artcraft-website/src/pages/create-image/generate-image-api.ts
+++ b/frontend/apps/artcraft-website/src/pages/create-image/generate-image-api.ts
@@ -1,4 +1,4 @@
-import { JobsApi, MediaFilesApi, OmniGenApi } from "@storyteller/api";
+import { HttpApiError, JobsApi, MediaFilesApi, OmniGenApi } from "@storyteller/api";
 import type { OmniGenImageRequest } from "@storyteller/api";
 import type { GeneratedImage } from "./create-image-store";
 
@@ -18,7 +18,12 @@ export interface GenerateImageParams {
 
 export async function enqueueImageGeneration(
   params: GenerateImageParams,
-): Promise<{ success: boolean; jobToken?: string; error?: string }> {
+): Promise<{
+  success: boolean;
+  jobToken?: string;
+  error?: string;
+  errorCode?: number;
+}> {
   const body: OmniGenImageRequest = {
     model: params.model,
     prompt: params.prompt,
@@ -40,6 +45,16 @@ export async function enqueueImageGeneration(
     }
     return { success: false, error: "Generation failed" };
   } catch (err: any) {
+    // ApiManager throws HttpApiError on non-2xx responses, carrying the
+    // server's `message` so it can be shown to the user instead of a bare
+    // status code.
+    if (err instanceof HttpApiError) {
+      return {
+        success: false,
+        error: err.serverMessage ?? err.message,
+        errorCode: err.status,
+      };
+    }
     return { success: false, error: err.message ?? "Request failed" };
   }
 }

--- a/frontend/apps/artcraft-website/src/pages/create-video/create-video.tsx
+++ b/frontend/apps/artcraft-website/src/pages/create-video/create-video.tsx
@@ -514,11 +514,31 @@ export default function CreateVideo() {
   // builds its label regex from `referenceImages`/`referenceVideos`/etc.) knows
   // about every `@ImageN` before the contentEditable does its DOM sync. Without
   // this ordering, only the last reference's mention would end up colored.
+  // Warn when a recreated generation's model is missing from the current
+  // model list: selectedModel silently falls back to the default model, and
+  // the restored prompt/settings may not be valid for it. Verified in its own
+  // effect because the model list may still be loading when the recreate
+  // payload is consumed.
+  const [recreateModelIdToVerify, setRecreateModelIdToVerify] = useState<
+    string | null
+  >(null);
+  useEffect(() => {
+    if (!recreateModelIdToVerify || apiModels.length === 0) return;
+    if (!apiModels.some((m) => m.model === recreateModelIdToVerify)) {
+      toast.error(
+        "The model used for this generation isn't available anymore. Using the default model instead.",
+      );
+    }
+    setRecreateModelIdToVerify(null);
+  }, [recreateModelIdToVerify, apiModels]);
+
   const pendingRecreate = useCreateVideoStore((s) => s.pendingRecreate);
   useEffect(() => {
     if (!pendingRecreate) return;
     const payload = useCreateVideoStore.getState().consumePendingRecreate();
     if (!payload) return;
+
+    if (payload.modelId) setRecreateModelIdToVerify(payload.modelId);
 
     flushSync(() => {
       setRefs({
@@ -719,18 +739,23 @@ export default function CreateVideo() {
   }, []);
 
   const handleGenerate = useCallback(async () => {
-    if (
-      !prompt.trim() ||
-      isGeneratingRef.current ||
-      needsImage ||
-      !selectedModel
-    ) {
+    if (!prompt.trim() || isGeneratingRef.current) {
       console.log("[generate-video] blocked", {
         hasPrompt: !!prompt.trim(),
         isGenerating: isGeneratingRef.current,
-        needsImage,
-        hasModel: !!selectedModel,
       });
+      return;
+    }
+    if (needsImage) {
+      toast.error(
+        "Add a starting frame: this model can't generate from text alone.",
+      );
+      return;
+    }
+    if (!selectedModel) {
+      // Models come from an API fetch; without one the submit would be a
+      // silent no-op, which reads as a dead button.
+      toast.error("Models are still loading. Try again in a moment.");
       return;
     }
     if (maxPromptLength !== undefined && prompt.length > maxPromptLength) {
@@ -832,6 +857,14 @@ export default function CreateVideo() {
 
       if (!result.success || !result.jobToken) {
         console.warn("[generate-video] enqueue failed", result.error);
+        // Always toast: batches that fail at enqueue never got a job token,
+        // so the gallery's failed-card rendering never shows them, and a
+        // silent failBatch here looks like the button did nothing.
+        if (result.errorCode === 402) {
+          toast.error("You're out of credits. Top up to keep generating.");
+        } else {
+          toast.error(result.error ?? "Failed to start generation");
+        }
         failBatch(batchId, result.error ?? "Failed to start generation");
       } else {
         setBatchJobToken(batchId, result.jobToken);
@@ -861,6 +894,7 @@ export default function CreateVideo() {
       }
     } catch (err) {
       console.error("[generate-video] unexpected error", err);
+      toast.error("Network error - please try again");
       failBatch(batchId, "Network error - please try again");
     }
 
@@ -956,7 +990,7 @@ export default function CreateVideo() {
             prompt={prompt}
             onPromptChange={setPrompt}
             onSubmit={handleGenerate}
-            isSubmitting={isGenerating || needsImage}
+            isSubmitting={isGenerating}
             credits={estimatedCredits}
             maxPromptLength={maxPromptLength}
             placeholder="Describe the video you want to generate..."

--- a/frontend/apps/artcraft-website/src/pages/create-video/generate-video-api.ts
+++ b/frontend/apps/artcraft-website/src/pages/create-video/generate-video-api.ts
@@ -1,4 +1,4 @@
-import { JobsApi, OmniGenApi } from "@storyteller/api";
+import { HttpApiError, JobsApi, OmniGenApi } from "@storyteller/api";
 import type { OmniGenVideoRequest } from "@storyteller/api";
 import type { GeneratedVideo } from "./create-video-store";
 
@@ -24,7 +24,12 @@ export interface GenerateVideoParams {
 
 export async function enqueueVideoGeneration(
   params: GenerateVideoParams,
-): Promise<{ success: boolean; jobToken?: string; error?: string }> {
+): Promise<{
+  success: boolean;
+  jobToken?: string;
+  error?: string;
+  errorCode?: number;
+}> {
   const body: OmniGenVideoRequest = {
     model: params.model,
     prompt: params.prompt,
@@ -60,6 +65,16 @@ export async function enqueueVideoGeneration(
     }
     return { success: false, error: "Generation failed" };
   } catch (err: any) {
+    // ApiManager throws HttpApiError on non-2xx responses, carrying the
+    // server's `message` (e.g. "Image is required") so it can be shown to
+    // the user instead of a bare status code.
+    if (err instanceof HttpApiError) {
+      return {
+        success: false,
+        error: err.serverMessage ?? err.message,
+        errorCode: err.status,
+      };
+    }
     return { success: false, error: err.message ?? "Request failed" };
   }
 }

--- a/frontend/libs/api/src/index.ts
+++ b/frontend/libs/api/src/index.ts
@@ -32,3 +32,4 @@ export * from "./lib/models/Character.js";
 export * from "./lib/models/Folder.js";
 export * from "./lib/config/StorytellerApiHostStore.js";
 export * from "./lib/enums/EIntermediateFile.js";
+export { HttpApiError } from "./lib/ApiManager.js";

--- a/frontend/libs/api/src/lib/ApiManager.ts
+++ b/frontend/libs/api/src/lib/ApiManager.ts
@@ -47,6 +47,30 @@ export interface ApiResponse<T, P = undefined> {
   pagination?: P;
 }
 
+/**
+ * Thrown on non-2xx responses. Carries the HTTP status and, when the server
+ * returned the standard `{ success, error_code, message }` error envelope,
+ * the human-readable `message` so callers can surface it to the user.
+ *
+ * The `message` string keeps the legacy `HTTP error! status: N` prefix so
+ * existing callers that regex the status out of `err.message` keep working.
+ */
+export class HttpApiError extends Error {
+  readonly status: number;
+  readonly serverMessage?: string;
+
+  constructor(status: number, serverMessage?: string) {
+    super(
+      serverMessage
+        ? `HTTP error! status: ${status} - ${serverMessage}`
+        : `HTTP error! status: ${status}`,
+    );
+    this.name = "HttpApiError";
+    this.status = status;
+    this.serverMessage = serverMessage;
+  }
+}
+
 export class ApiManager {
   ApiTargets: Record<string, string> = {};
 
@@ -105,7 +129,20 @@ export class ApiManager {
     });
 
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      let serverMessage: string | undefined;
+      try {
+        const errorBody = await response.json();
+        if (
+          errorBody &&
+          typeof errorBody.message === "string" &&
+          errorBody.message.length > 0
+        ) {
+          serverMessage = errorBody.message;
+        }
+      } catch {
+        // Non-JSON error body; fall back to the bare status.
+      }
+      throw new HttpApiError(response.status, serverMessage);
     }
 
     return response.json();


### PR DESCRIPTION
Users reported that after using **Recreate**, pressing the generate arrow did nothing at all (no error, no card, no spinner). Root cause: several failure paths gave zero feedback, so a rejected request looked like a dead button or an outage.

### Changes

- **Show real error messages.** The API layer now keeps the server's error message (e.g. "Image is required") instead of throwing it away, so users see why a generation was rejected.
- **Toast on every failed submit.** Image and video pages (webapp + website) now show an error toast when a generation fails to start. Previously, most failures were recorded invisibly and never shown.
- **Out of credits feedback on the website.** 402 responses now show a toast (webapp keeps its upgrade modal).
- **Network errors are announced** instead of failing silently.
- **No more silent submit blocks.** Cases that used to quietly ignore the click now explain themselves:
  - Model list still loading
  - Model needs a starting image (website; also un-disabled the button so clicking gives feedback)
- **Recreate model fallback is announced.** If the original generation's model is no longer available, recreate now tells the user it switched to the default model instead of silently swapping.