### PR TITLE
Promptbox: image ref mention chips

### DIFF
--- a/frontend/apps/artcraft-webapp/src/pages/create-video/create-video.tsx
+++ b/frontend/apps/artcraft-webapp/src/pages/create-video/create-video.tsx
@@ -603,6 +603,10 @@ export default function CreateVideo() {
             label: `@Image${i + 1}`,
             type: "image" as const,
             preview: img.url,
+            // `url` is the thumbnail — the chip Preview modal renders at
+            // natural size, so it needs the full-res image (same fallback
+            // the deck cards use).
+            fullPreview: img.fullUrl ?? img.url,
           })),
           ...referenceVideos.map((vid, i) => ({
             label: `@Video${i + 1}`,

--- a/frontend/libs/components/promptbox/src/lib/MentionChipMenu.tsx
+++ b/frontend/libs/components/promptbox/src/lib/MentionChipMenu.tsx
@@ -1,7 +1,14 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { twMerge } from "tailwind-merge";
-import { ChevronLeftIcon, EyeIcon, RefreshCwIcon, Trash2Icon, UserIcon } from "lucide-react";
+import {
+  ChevronLeftIcon,
+  EyeIcon,
+  ImageIcon,
+  RefreshCwIcon,
+  Trash2Icon,
+  UserIcon,
+} from "lucide-react";
 import type { MentionItem } from "./MentionTextarea";
 
 const VIEWPORT_MARGIN = 8;
@@ -15,6 +22,15 @@ const OPEN_GRACE_MS = 700;
 const MENU_ROW =
   "flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm text-base-fg transition-colors hover:bg-ui-controls/60 cursor-pointer";
 
+// Header subtitle and empty-replace-list copy per chip type.
+const TYPE_COPY: Record<MentionItem["type"], { title: string; empty: string }> =
+  {
+    character: { title: "Character", empty: "No other characters" },
+    image: { title: "Image reference", empty: "No other images" },
+    video: { title: "Video reference", empty: "No other videos" },
+    audio: { title: "Audio reference", empty: "No other audio" },
+  };
+
 export interface MentionChipMenuProps {
   /** Viewport-space rect of the clicked chip. */
   anchorRect: DOMRect;
@@ -26,9 +42,11 @@ export interface MentionChipMenuProps {
   anchorNode?: HTMLElement;
   /** Canonical mention label including the "@", e.g. "@robot cartoon". */
   currentLabel: string;
-  /** Avatar of the currently attached character, shown in the menu header. */
+  /** Chip type — drives the header subtitle and fallback avatar icon. */
+  currentType?: MentionItem["type"];
+  /** Thumbnail of the current mention, shown in the menu header. */
   currentPreview?: string;
-  /** Characters offered as replacements (current one excluded by the caller). */
+  /** Same-type mentions offered as replacements (current one excluded by the caller). */
   replaceItems: MentionItem[];
   onReplace: (item: MentionItem) => void;
   onPreview: () => void;
@@ -37,9 +55,9 @@ export interface MentionChipMenuProps {
 }
 
 /**
- * Floating menu for an inline character-mention chip: Replace / Preview /
- * Remove, with the Replace action swapping to a second "Back" panel listing
- * the other available characters.
+ * Floating menu for an inline mention chip (character or image ref):
+ * Replace / Preview / Remove, with the Replace action swapping to a second
+ * "Back" panel listing the other same-type mentions.
  *
  * Portaled to document.body with fixed positioning — the promptbox `.glass`
  * container (backdrop-blur) is a containing block that would trap
@@ -49,6 +67,7 @@ export function MentionChipMenu({
   anchorRect,
   anchorNode,
   currentLabel,
+  currentType = "character",
   currentPreview,
   replaceItems,
   onReplace,
@@ -193,7 +212,11 @@ export function MentionChipMenu({
               aria-label={`View ${currentName}`}
               className="group/avatar relative shrink-0 cursor-pointer overflow-hidden rounded-md"
             >
-              <ChipAvatar preview={currentPreview} name={currentName} />
+              <ChipAvatar
+                preview={currentPreview}
+                name={currentName}
+                type={currentType}
+              />
               <span className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover/avatar:opacity-100">
                 <EyeIcon  className="h-3 w-3 text-white" />
               </span>
@@ -202,7 +225,9 @@ export function MentionChipMenu({
               <div className="truncate text-sm font-medium text-base-fg">
                 {currentName}
               </div>
-              <div className="text-[11px] text-base-fg/50">Character</div>
+              <div className="text-[11px] text-base-fg/50">
+                {TYPE_COPY[currentType].title}
+              </div>
             </div>
           </div>
           <div className="my-1 border-t border-ui-panel-border" />
@@ -247,7 +272,7 @@ export function MentionChipMenu({
           <div className="max-h-64 overflow-y-auto">
             {replaceItems.length === 0 && (
               <div className="px-2 py-3 text-center text-xs text-base-fg/50">
-                No other characters
+                {TYPE_COPY[currentType].empty}
               </div>
             )}
             {replaceItems.map((item, i) => (
@@ -258,7 +283,11 @@ export function MentionChipMenu({
                 onPointerDown={handleRowKeyActivate}
                 onClick={() => onReplace(item)}
               >
-                <ChipAvatar preview={item.preview} name={item.label} />
+                <ChipAvatar
+                  preview={item.preview}
+                  name={item.label}
+                  type={item.type}
+                />
                 <span className="min-w-0 flex-1 truncate text-left">
                   {item.label.replace(/^@/, "")}
                 </span>
@@ -272,13 +301,22 @@ export function MentionChipMenu({
   );
 }
 
-function ChipAvatar({ preview, name }: { preview?: string; name: string }) {
+function ChipAvatar({
+  preview,
+  name,
+  type = "character",
+}: {
+  preview?: string;
+  name: string;
+  type?: MentionItem["type"];
+}) {
+  const FallbackIcon = type === "character" ? UserIcon : ImageIcon;
   return (
     <div className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-md border border-white/10 bg-black/20">
       {preview ? (
         <img src={preview} alt={name} className="h-full w-full object-cover" />
       ) : (
-        <UserIcon  className="h-3.5 w-3.5 text-base-fg/60" />
+        <FallbackIcon  className="h-3.5 w-3.5 text-base-fg/60" />
       )}
     </div>
   );

--- a/frontend/libs/components/promptbox/src/lib/MentionTextarea.tsx
+++ b/frontend/libs/components/promptbox/src/lib/MentionTextarea.tsx
@@ -135,6 +135,15 @@ function isChip(node: Node): node is HTMLElement {
   );
 }
 
+/**
+ * Mention types that render as atomic thumbnail chips (vs colored text).
+ * Video/audio refs stay as text: audio has no thumbnail, and a video frame
+ * shrunk to chip size is unreadable.
+ */
+function rendersAsChip(item: MentionItem): boolean {
+  return item.type === "character" || item.type === "image";
+}
+
 /** Nearest chip element enclosing `node` (up to `root`), or null. */
 function chipContaining(root: HTMLElement, node: Node | null): HTMLElement | null {
   let current: Node | null = node;
@@ -697,11 +706,11 @@ export const MentionTextarea = forwardRef<HTMLDivElement, MentionTextareaProps>(
       return m;
     }, [mentionItems]);
 
-    // Lowercased labels that render as atomic chips (characters only).
+    // Lowercased labels that render as atomic chips (characters + images).
     const chipLabels = useMemo(() => {
       const s = new Set<string>();
       for (const item of mentionItems) {
-        if (item.type === "character") s.add(item.label.toLowerCase());
+        if (rendersAsChip(item)) s.add(item.label.toLowerCase());
       }
       return s;
     }, [mentionItems]);
@@ -743,9 +752,9 @@ export const MentionTextarea = forwardRef<HTMLDivElement, MentionTextareaProps>(
     );
 
     /**
-     * Markup for one atomic character chip. data-mention keeps the exact
-     * typed text so serialization is lossless; the visible chip shows the
-     * name without the "@".
+     * Markup for one atomic mention chip (character or image ref).
+     * data-mention keeps the exact typed text so serialization is lossless;
+     * the visible chip shows the name without the "@".
      */
     const buildChipHTML = useCallback(
       (item: MentionItem, matchText: string): string => {
@@ -766,8 +775,8 @@ export const MentionTextarea = forwardRef<HTMLDivElement, MentionTextareaProps>(
       [lowerColorMap],
     );
 
-    // Build innerHTML with mentions inline: character mentions render as
-    // atomic thumbnail chips, other reference types as colored text.
+    // Build innerHTML with mentions inline: character and image-ref mentions
+    // render as atomic thumbnail chips, other reference types as colored text.
     const buildHTML = useCallback(
       (text: string): string => {
         if (!text) return "";
@@ -794,7 +803,7 @@ export const MentionTextarea = forwardRef<HTMLDivElement, MentionTextareaProps>(
             html += escapeHTML(text.slice(lastIndex, match.index));
           }
 
-          if (item?.type === "character") {
+          if (item && rendersAsChip(item)) {
             html += buildChipHTML(item, fullMatch);
             endsWithChip = true;
           } else if (color) {
@@ -1282,39 +1291,35 @@ export const MentionTextarea = forwardRef<HTMLDivElement, MentionTextareaProps>(
       }
     }, [chipMenu, selectChipRange, handleInput, chipStart, value, onChange]);
 
-    const handleChipPreview = useCallback(() => {
-      if (!chipMenu) return;
-      const item =
-        (chipMenu.token &&
-          mentionItems.find(
-            (i) => i.type === "character" && i.token === chipMenu.token,
-          )) ||
-        resolveItem(chipMenu.label);
-      setChipMenu(null);
-      if (item) setPreviewItem(item);
-    }, [chipMenu, mentionItems, resolveItem]);
-
+    /** The mention item the open chip menu refers to (token beats label). */
     const chipMenuItem = useMemo(() => {
       if (!chipMenu) return undefined;
       return (
         (chipMenu.token &&
-          mentionItems.find(
-            (i) => i.type === "character" && i.token === chipMenu.token,
-          )) ||
+          mentionItems.find((i) => i.token === chipMenu.token)) ||
         resolveItem(chipMenu.label)
       );
     }, [chipMenu, mentionItems, resolveItem]);
 
+    const handleChipPreview = useCallback(() => {
+      if (!chipMenu) return;
+      setChipMenu(null);
+      if (chipMenuItem) setPreviewItem(chipMenuItem);
+    }, [chipMenu, chipMenuItem]);
+
+    // Swap candidates: other mentions of the same type as the clicked chip
+    // (characters swap with characters, image refs with image refs).
     const replaceItems = useMemo(() => {
       if (!chipMenu) return [];
+      const chipType = chipMenuItem?.type ?? "character";
       return mentionItems.filter(
         (i) =>
-          i.type === "character" &&
+          i.type === chipType &&
           (chipMenu.token
             ? i.token !== chipMenu.token
             : i.label.toLowerCase() !== chipMenu.label.toLowerCase()),
       );
-    }, [chipMenu, mentionItems]);
+    }, [chipMenu, chipMenuItem, mentionItems]);
 
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -1355,8 +1360,8 @@ export const MentionTextarea = forwardRef<HTMLDivElement, MentionTextareaProps>(
 
         // Atomic chip deletion: native contenteditable=false removal is
         // inconsistent across browsers (Safari especially), so when the caret
-        // sits at a character-mention boundary, delete the whole label from
-        // the plain-text value in one keypress.
+        // sits at a chip-mention boundary, delete the whole label from the
+        // plain-text value in one keypress.
         if (
           (e.key === "Backspace" || e.key === "Delete") &&
           chipLabels.size > 0 &&
@@ -1592,6 +1597,7 @@ export const MentionTextarea = forwardRef<HTMLDivElement, MentionTextareaProps>(
             anchorRect={chipMenu.rect}
             anchorNode={chipMenu.node}
             currentLabel={chipMenu.label}
+            currentType={chipMenuItem?.type ?? "character"}
             currentPreview={chipMenuItem ? chipMenuItem.preview : undefined}
             replaceItems={replaceItems}
             onReplace={handleChipReplace}


### PR DESCRIPTION
- `@ImageN` mentions now render as thumbnail chips, same as characters
- Chip menu (Replace / Preview / Remove) works on image chips; Replace lists same-type refs only
- Chip menu shows type-aware subtitle, empty text, and fallback icon
- Fix: webapp chip Preview showed thumbnail-size image - now passes full-res `fullUrl`
- Video/audio mentions unchanged (still colored text); website's old copy untouched