### PR TITLE
HM-928: Fix dev_setup.md missing cmake + global nx prerequisites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,3 +94,114 @@ Organize for top-to-bottom reading. Important things first, details later.
 
   Not: `| Model | Configuration | Credits | Speed | Score |` packed tight
   with varying widths per row.
+
+---
+
+# Project: ArtCraft MCP (fork-local — everything below governs work on this fork only)
+
+Guidance for executing the ArtCraft MCP project (embedded control server + standalone MCP server). It is planned in Linear; this section keeps every session on-rails. Upstream conventions above still apply to all code.
+
+- **Project:** ArtCraft MCP
+- **Domain:** software
+- **Tools & channels:** Rust (axum control server in the Tauri app), TypeScript (`mcp/artcraft-mcp` with @modelcontextprotocol/sdk), Ollama MCP for local-model dispatch, MCP inspector, Claude Code / Codex as executors
+- **Repo / default branch:** github.com/performance-clickt/artcraft (upstream: storytold/artcraft) / `main`
+- **Linear team / project:** Hive Mind / [ArtCraft MCP](https://linear.app/clickt/project/artcraft-mcp-6759fa1b04b7)
+- **Milestones (integration checkpoints):** M1 Baseline build → M2 Control server (Path A) → M3 Scene bridge → M4 MCP server → M5 Verification & evals
+- **Lessons Log:** the Linear document named "Lessons Log" on the ArtCraft MCP project
+- **Orientation docs:** `docs/PROJECT.md`, full plan in `docs/artcraft-mcp-brief.md`
+
+## Session start
+
+Before pulling an issue:
+
+1. Read the project's **Lessons Log** document in Linear and apply any relevant entries.
+2. Pull the next issue from the project and read it in full — it contains everything needed to execute that task.
+
+## Linear is the source of truth
+
+Every unit of work is a Linear issue, and each issue is written to be executed as a standalone prompt.
+
+- **Execute only what the issue specifies.** If the issue is missing context or contains an unresolved decision, stop and flag it rather than improvising — a well-formed issue shouldn't need outside context.
+- **Update issue status** as you move: claim it (In Progress) when you start — this claim happens *before* any git action and is the lock that stops two agents taking one issue — and done only when acceptance criteria are proven, reflect has run, and the PR is merged.
+- **Never work off-Linear.** If new work surfaces mid-project, create an issue for it rather than silently expanding scope.
+- **Assume parallel agents.** Other agents may be executing other issues at the same time. Coordinate only through Linear: an In-Progress issue is owned — never start it. Pick only unclaimed, unblocked issues.
+
+## Linear sync at issue boundaries
+
+Exactly two comments per issue:
+
+- **On starting**: post the todo plan as a comment — checkable items for what you're about to do.
+- **On completing**: post one wrap-up comment: what changed, verification evidence (tests/checks pass, curl or inspector output, behavior demonstrated), deviations from the plan, the reflect verdict, the PR link and its check status. Then update the issue status.
+- **No per-item progress comments.** (Status transitions and Lessons Log appends are separate normal actions, not counted against this cap.)
+- If a Linear write fails, don't block the work: note the failure and fold the missed update into the completion comment or the next session.
+
+Track the plan locally as checkable items (`tasks/todo.md` or your todo tool) while you work; the Linear comments are the record.
+
+## Lessons Log
+
+The project's Linear document "Lessons Log" is the single canonical store of lessons. There is no local lessons file.
+
+- **After any correction from the user** (or a review pass that surfaces a repeatable mistake): append one line **immediately**, before resuming work — format: `pattern → rule that prevents it (issue ID)`.
+- If the append fails, record the lesson in the issue's completion comment and append it at the next session start.
+
+## Token efficiency: Ollama MCP dispatch
+
+Local models are verified present: `devstral-small-2:latest` (code-oriented) and `muse-glimmer:30b-mlx` (prose/brainstorming). Use `mcp__ollama__ollama_dispatch` for mechanical, high-token, low-judgment work instead of spending frontier context:
+
+- **Good dispatches:** summarizing long upstream source files, extracting struct/signature/field lists, first-draft boilerplate (repetitive endpoint bodies, TS invoke wrappers, README/eval drafts), reformatting. Pass `files`/`file_globs` so file contents never enter frontier context.
+- **Never dispatch:** final review, verification, correctness judgments, acceptance-criteria checks, or anything a person will rely on unreviewed. Local-model output is an untrusted draft — verify it against the real source before using it.
+
+## Codex handoff
+
+Issues are written to be executable cold by Claude Code **or** Codex. Well-bounded implementation issues (self-contained TS tool batches, single-module endpoint work — flagged "Codex-friendly" in their Notes) may be dispatched to Codex via the `codex:codex-rescue` agent or `codex:rescue` skill. The dispatching agent still owns the CLAUDE.md gates: Linear claim, verification, reflect, PR, and merge approval are never delegated to Codex.
+
+## Reflexion at the end of every issue
+
+Before marking any issue done, run:
+
+```
+/reflexion:reflect
+```
+
+- **Let the skill triage, never pre-triage.** Do not decide "this issue is trivial, skipping reflect" — invoke it and let its own complexity triage route trivial changes to its quick path.
+- **Record the verdict** in the completion comment: path taken, confidence, any issues found and fixed. Never write a verdict reflect didn't produce.
+- An issue is not done until reflect passes and acceptance criteria are proven.
+
+## Milestone integration check
+
+At each milestone boundary (M1→M5 above), before starting the next milestone's issues:
+
+1. Run the milestone verification across the whole milestone, not just the last issue — M1: stock build runs logged-in; M2: full curl matrix incl. 401s + one cheap generation; M3: scene ops with tab open/closed + timeout path; M4: 16/16 tools in inspector; M5: e2e prompt + eval scorecard. `SQLX_OFFLINE=true cargo check -p artcraft` and `npm run build` (in `mcp/artcraft-mcp`) must be clean at every boundary.
+2. **Re-read every issue in the milestone** and verify its acceptance criteria still hold in the assembled state.
+3. **Read the Lessons Log and the milestone's completion comments** for unresolved flags. Resolve mechanical items; file follow-up issues for judgment calls. Flag missing verification evidence — don't backfill it.
+4. **Post a milestone summary comment** on the project recording verification results and how each flag was handled.
+
+## Git workflow
+
+Repo: **github.com/performance-clickt/artcraft** · default branch: **`main`** · upstream remote: `storytold/artcraft` (rebase target for future releases — never push to it). Every issue is delivered on its own branch and PR. **Assume other agents are working other issues in parallel.** Per issue, in order:
+
+1. **Claim before touching git.** Move the issue to In Progress and self-assign in Linear *first*.
+2. **Isolate in a worktree.** From an up-to-date `main`, create a git worktree on a new branch named with the issue's Linear `gitBranchName`. One issue = one branch = one worktree = one agent. Never work on `main`.
+3. **Commit small.** Focused commits referencing the issue key (e.g. `HM-916: …`).
+4. **Open a PR** to `main` on the fork with the issue key in the title. Rebase on latest `main` first; never force-push `main`.
+5. **Verify.** Green per the issue's acceptance criteria, reflect passed. Prove it before asking for merge.
+6. **Stop for merge approval — never self-merge.** Post the wrap-up comment with PR link and evidence, ask John to approve. Only after approval: merge, delete branch, remove worktree, mark done.
+
+Parallel-safety: claim in Linear before any git action; never start an issue whose `blockedBy` isn't merged; small PRs merged promptly; rebase, don't force.
+
+**Patch hygiene (this fork's extra rule):** all project logic lives in NEW files. Only these upstream files may be edited: root `Cargo.toml`, `crates/desktop/artcraft/Cargo.toml`, `crates/desktop/artcraft/src/lib.rs`, `core/lifecycle/startup/handle_tauri_startup.rs`, `crates/schema/public/enums/src/tauri/ux/tauri_event_name.rs`, `frontend/apps/artcraft/app/src/root.tsx`, `frontend/libs/tauri-events/src/index.ts`, `frontend/libs/tauri-api/src/index.ts` (plus append-only `mod.rs` lines). Editing any other upstream file needs a stated reason in the PR.
+
+**Linear ↔ GitHub linkage:** use the exact `gitBranchName` and issue key so Linear auto-links. If the integration isn't enabled, update issue status through the Linear MCP manually at each step.
+
+## Plan mode + verification gates
+
+- **Plan first.** For any non-trivial task (3+ steps or a structural decision), enter plan mode before executing. If something goes sideways mid-execution, stop and re-plan.
+- **Verification before done.** Never mark an issue complete without proving it: tests/checks pass, curl or inspector evidence captured, behavior demonstrated in the running app.
+- **Autonomous fixing.** Given a failing check, fix it — point at the evidence and resolve it rather than asking for hand-holding.
+- **Credit discipline.** Generations spend real credits: always check `estimate_cost` first, use the cheapest model and `batch_size: 1` for verification, and never exceed an issue's stated spend budget.
+
+## Core principles
+
+- **Simplicity first.** The smallest change that works.
+- **No laziness.** Root causes, no band-aid fixes.
+- **Minimal impact.** Touch only what's necessary — especially upstream files (see patch hygiene).

--- a/_docs/dev_setup.md
+++ b/_docs/dev_setup.md
@@ -7,10 +7,11 @@ ArtCraft is a Rust / Tauri app.
 
 To set up the ArtCraft development environment,  install the following:
 
-1. [Install Rust](https://doc.rust-lang.org/cargo/getting-started/installation.html).
-2. [Install npm](https://nodejs.org/en/download) or [nvm](https://github.com/nvm-sh/nvm). (Node version `v24.13.0` works at time of writing.) 
-3. [Install nx](https://nx.dev/docs/getting-started/installation). (Nx version `v22.4.5` works at time of writing.)
-4. [Install Tauri CLI](https://v2.tauri.app/reference/cli/). (Version `tauri-cli 2.10.0` works at time of writing.)
+1. [Install Rust](https://doc.rust-lang.org/cargo/getting-started/installation.html). (rustc/cargo version `1.96.0` works at time of writing.)
+2. Install cmake, e.g. `brew install cmake` on macOS. (Version `4.4.2` works at time of writing.) This is required to build BoringSSL via `boring-sys2` (a dependency of `wreq`); without it, the Rust build fails with "is `cmake` not installed?".
+3. [Install npm](https://nodejs.org/en/download) or [nvm](https://github.com/nvm-sh/nvm). Node `v22.22.2` / npm `10.9.7` work at time of writing (minimum: Node ≥ 20).
+4. [Install nx](https://nx.dev/docs/getting-started/installation) **globally** (`npm install -g nx`). Nx version `23.1.1` works at time of writing. The frontend dev script calls bare `nx`, which is not resolved from `node_modules/.bin` when run from a shell script, so a global install is required.
+5. [Install Tauri CLI](https://v2.tauri.app/reference/cli/). (Version `cargo-tauri 2.11.4` works at time of writing.)
 
 An easy way to get started with running the app in development is to run the two commands (in separate terminals):
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -1,0 +1,29 @@
+# ArtCraft MCP
+
+**Brief:** [artcraft-mcp-brief.md](./artcraft-mcp-brief.md)
+**Linear project:** https://linear.app/clickt/project/artcraft-mcp-6759fa1b04b7
+**Team:** Hive Mind
+**Lessons Log:** the Linear document named "Lessons Log" on this project
+**Domain:** software
+**Client-facing identity:** John Greenhow (personal tooling; fork of open-source storytold/artcraft)
+**Tools & channels:** Fork at github.com/performance-clickt/artcraft (upstream storytold/artcraft), Linear (Hive Mind), Ollama MCP (devstral-small-2, muse-glimmer:30b-mlx) for token-efficient dispatch, Codex as optional executor, MCP inspector for testing
+
+## Summary
+
+Patch the open-source ArtCraft Tauri desktop app with an embedded loopback control server (axum, token-authenticated, ephemeral port + discovery file) and build a standalone TypeScript MCP server so Claude Code or Codex can drive the live app: image/video/3D generation, task queue, library, and real-time 3D scene editing via a webview bridge. The running release app has no external control surface, so the app is built from source on a fork kept rebasable on upstream (8 edited files, all logic in new files).
+
+## Milestones
+
+1. **M1 — Baseline** — fork wired, stock dev build runs, login reused
+2. **M2 — Control server (Path A)** — axum server, auth, models/credits/cost, generation, tasks/media endpoints; curl matrix green
+3. **M3 — Scene bridge** — Rust event↔oneshot bridge + frontend ControlBridge; live scene ops via curl
+4. **M4 — MCP server** — mcp/artcraft-mcp, 16 tools, inspector green
+5. **M5 — Verification & evals** — Claude Code end-to-end flow + 10 read-only evals
+
+## Key decisions
+
+See the brief's **Coordination** and **Architecture** sections — decisions made after planning live in the affected Linear issues, not here.
+
+## How work happens here
+
+All work is tracked in Linear; every issue is written to be executed as a standalone prompt. Session rules live in the root [CLAUDE.md](../CLAUDE.md). This document is orientation only — no status, no task lists (they would drift from Linear, and Linear wins).

--- a/docs/artcraft-mcp-brief.md
+++ b/docs/artcraft-mcp-brief.md
@@ -1,0 +1,143 @@
+# ArtCraft MCP: Live App Control ("patched app + live control")
+
+## Coordination (project-coordinator handoff)
+
+- **Linear**: project "ArtCraft MCP" under team **Hive Mind**, with milestones below, every issue a standalone prompt (Objective/Context/Task/Acceptance/Notes), a "Lessons Log" project document, phase labels + priority ladder + blockedBy for true dependencies only.
+- **Git**: fork `storytold/artcraft` → `performance-clickt/artcraft` (gh is authed as performance-clickt). `origin` = fork, `upstream` = storytold. Unshallow the clone (`git fetch --unshallow`). Per-issue branch + worktree + PR; agent claims the Linear issue before touching git; user approves merges — no self-merging.
+- **Root docs**: `docs/PROJECT.md` + brief + `tasks/todo.md` + customized root `CLAUDE.md` in the repo clone at `/Users/johngreenhow/Artcraft/artcraft-src`. Repo already ships an upstream `CLAUDE.md` → merge, never overwrite (project sections appended with approval).
+- **Token efficiency (Ollama MCP)**: local models verified present — `devstral-small-2:latest` (code) and `muse-glimmer:30b-mlx`. CLAUDE.md policy: use `mcp__ollama__ollama_dispatch` for mechanical, high-token, low-judgment work — summarizing long upstream files, extracting schemas/signatures, first-draft boilerplate (repetitive axum endpoint bodies, TS invoke wrappers, eval question drafts) with `files`/`file_globs` so file contents never enter frontier context. Ollama output is untrusted: Claude/Codex reviews and integrates; never use local models for final review, verification, or correctness judgments.
+- **Codex handoff**: issues are written to be executable by Claude Code *or* Codex cold. Well-bounded implementation issues (single-file endpoint batches, TS tool wrappers) may be dispatched via the `codex:codex-rescue` agent / `codex:rescue` skill; verification still runs in the primary agent per CLAUDE.md gates.
+
+### Milestones & issues
+
+**M1 — Baseline: fork + stock build runs** (integration check: unmodified app builds, launches, reuses login)
+1. Fork repo, rewire remotes, unshallow, branch strategy (Ops)
+2. Verify toolchain + run stock dev build end-to-end (Node≥20/npm/tauri-cli/Rust; both dev scripts; app launches logged-in)
+
+**M2 — Control server, Path A** (integration check: curl matrix green incl. 401s; cheap image gen via curl)
+3. Control server skeleton: axum + spawn thread + discovery/state file (0600) + bearer auth + `/v1/health`
+4. Read endpoints: `/v1/models`, `/v1/credits`, `/v1/estimate_cost`
+5. Generation endpoints: `/v1/generate/{image,video,object,world,bg_removal}`
+6. Task + media endpoints: `/v1/tasks`, `/v1/tasks/{id}`, `/v1/media/download`, `/v1/media` (list via artcraft_client)
+
+**M3 — Scene bridge** (integration check: scene ops via curl with 3D tab open; SCENE_NOT_ACTIVE + timeout paths verified)
+7. Rust bridge: `TauriEventName::ControlSceneRequest`, event struct, `ControlBridgeState` oneshot map, `control_bridge_reply_command`, `/v1/scene/{op}`
+8. Frontend bridge: event hook (tauri-events), reply wrapper (tauri-api), `ControlBridge.tsx`, `root.tsx` mount, index exports
+
+**M4 — MCP server** (integration check: all 16 tools green in MCP inspector)
+9. Scaffold `mcp/artcraft-mcp` + control-client (discovery, auth, health, truncation) + status/models/cost tools
+10. Generation + task tools: `generate_*`, `remove_background`, `list_tasks`, `wait_for_task`
+11. Media + scene tools: `download_media`, `list_media`, `scene_list_objects`, `scene_get`, `scene_apply`, `scene_update_object`
+12. README + Claude Code/Codex registration docs + inspector smoke run
+
+**M5 — Verification & evals** (integration check: e2e prompt passes; eval suite recorded)
+13. End-to-end via Claude Code: register MCP, run "generate image → place in scene → move it" flow live
+14. Author + run 10 read-only evals per build-mcp skill (seeded 3-object scene + known library item)
+
+Execution order: milestone order; within milestone, ascending issue number; 3↔4 and 9↔10↔11 pairs parallelizable across agents after their skeleton issue lands; blockedBy only across milestones' true gates (2→3, 3→4/5/6, 7→8, 9→10/11, 12→13, 13→14).
+
+
+## Context
+
+John wants to drive the ArtCraft desktop app (AI image/video/3D scene IDE, open-source Tauri app) from Claude Code or Codex — no LLM API keys inside the app. The running release app is a closed box (no local server, IPC, deep links, or devtools), so we patch the app source (cloned at `/Users/johngreenhow/Artcraft/artcraft-src`) to embed a loopback control server, and build a standalone MCP server that talks to it. John chose this over a backend-API-only MCP because he wants Claude to drive the *live* window (real-time scene edits he can watch). Built per the `mcp:build-mcp` skill.
+
+Bonus alignment: the repo's own `pagescene/CLAUDE.md` describes a planned-but-unbuilt "LLM edits the scene-descriptor JSON" feature — this ships that design externally.
+
+## Architecture
+
+```
+Claude Code ──stdio──> MCP server (TypeScript, mcp/artcraft-mcp/)
+                          │ HTTP + Bearer token (discovery: ~/Artcraft/state/control_server.json)
+                          ▼
+              Control server (axum, in-app, 127.0.0.1:ephemeral)
+               ├─ Path A: directly calls existing command handle_request fns via AppHandle state
+               │   (generate image/video/mesh/world, models, cost, tasks, credits, downloads, library)
+               └─ Path B: scene bridge → Tauri event → <ControlBridge/> in webview
+                   → getActiveEditor() / applyJson() / getSceneJson() → reply command → oneshot correlation
+```
+
+Key facts (verified):
+- Dev build works with no secrets: `SQLX_OFFLINE=true`, no signing/updater/integrity checks; local build shares `~/Artcraft` data dir + cookie jar (`~/Library/Caches/ai.artcraft.app/.cookies`) with the installed app, so it **reuses the existing login**.
+- Webview CSP blocks `fetch` to 127.0.0.1 → control server lives Rust-side; webview only sees Tauri events/commands. No CSP/capability changes.
+- `getActiveEditor(): Editor | null` is a module global explicitly for non-React callers ([EngineContext.tsx:16-26](frontend/libs/components/pagescene/src/lib/contexts/EngineContext/EngineContext.tsx)); `editor.applyJson(jsonString)` ([editor.ts:912]) + `editor.save_manager.getSceneJson({sceneGenerationMetadata})` ([save_manager.ts:142]) round-trip the scene. Null when the 3D tab isn't mounted → `SCENE_NOT_ACTIVE` error.
+- Scene JSON: `{version, scene: ObjectJSON[], positivePrompt, cameraAspectRatio, timeline, skybox, camera_data, cameras, selectedCameraId}`; `ObjectJSON` in `proxy/storyteller_proxy_3d_object.ts`.
+- Existing patterns to mirror: background thread (`core/threads/third_party_task_polling_thread/`), spawn task files (`core/lifecycle/startup/tasks/spawn_*.rs`), command file layout (`core/commands/media_files/media_file_delete_command.rs`), events (`BasicSendableEvent` + `TauriEventName` enum + hand-mirrored TS hooks in `frontend/libs/tauri-events`), invoke wrappers (`frontend/libs/tauri-api`, payload nests `{request: {...}}`).
+
+## Control protocol
+
+- Discovery file `~/Artcraft/state/control_server.json` (0600): `{version, pid, port, token, started_at}`; token 32-byte hex per launch; `Authorization: Bearer <token>` on every request.
+- Envelope: `{"success": true, "data": ...}` | `{"success": false, "error": {"code", "message"}}`. Codes: `UNAUTHORIZED, BAD_REQUEST, NOT_LOGGED_IN, SCENE_NOT_ACTIVE, SCENE_BRIDGE_TIMEOUT, TASK_NOT_FOUND, UPSTREAM_API_ERROR, INTERNAL`.
+- Endpoints: `GET /v1/health`, `GET /v1/models?kind=image|video`, `POST /v1/estimate_cost`, `POST /v1/generate/{image,video,object,world,bg_removal}`, `GET /v1/tasks[?limit&cursor]`, `GET /v1/tasks/{id}`, `POST /v1/media/download`, `GET /v1/media?search&cursor&limit` (new thin handler over `artcraft_client` + `StorytellerCredentialManager` — single auth path; do NOT parse the cookie jar in the MCP server), `GET /v1/credits`, `POST /v1/scene/{status,list_objects,get_scene,apply_scene,update_object}`.
+- Scene bridge: endpoint makes `request_id: Uuid` + `oneshot::Sender` in managed `ControlBridgeState{pending: Mutex<HashMap<..>>}` → emits `ControlSceneRequestEvent{request_id, op, payload}` → `<ControlBridge/>` executes against `getActiveEditor()` → replies via new `control_bridge_reply_command` → handler fires the oneshot; HTTP side `tokio::time::timeout(10s)`.
+
+## MCP tools (16, TypeScript, @modelcontextprotocol/sdk, stdio)
+
+No `artcraft_` prefix (Claude Code namespaces as `mcp__artcraft__*`). List tools take `response_format: concise|detailed` (default concise), `limit`/`cursor`; responses capped ~25k chars with truncation notice.
+
+| Tool | Notes |
+|--------------------------|--------------------------------------------------------------|
+| `get_status`             | version, logged_in, credits                                  |
+| `list_models`            | kind=image\|video                                            |
+| `estimate_cost`          | pre-flight credits                                           |
+| `generate_image`         | wait=true default, timeout_seconds=180                       |
+| `generate_video`         | returns task_id → "use wait_for_task" (minutes-long)         |
+| `generate_3d_object`     | image → mesh, task_id                                        |
+| `generate_3d_world`      | image → splat/world, task_id                                 |
+| `remove_background`      | wait=true default                                            |
+| `list_tasks`             | queue snapshot                                               |
+| `wait_for_task`          | poll 3s, timeout cap 300s; timeout = normal outcome, not error |
+| `download_media`         | media_token → local path                                     |
+| `list_media`             | library list/search                                          |
+| `scene_list_objects`     | token-light rows (uuid, name, transform, visible, locked)    |
+| `scene_get`              | full scene JSON                                              |
+| `scene_apply`            | replaces scene (description warns)                           |
+| `scene_update_object`    | transform/rename/show-hide one object by uuid (bridge does get→patch→applyJson) |
+
+Errors are actionable: "ArtCraft is not running. Launch the patched app, then retry."; "Open the 3D scene tab in ArtCraft first."
+
+## File manifest
+
+**New Rust** (under `crates/desktop/artcraft/src/core/`): `control_server/{mod.rs, state/control_server_settings.rs, state/control_bridge_state.rs, state_file/write_control_state_file.rs, auth/bearer_auth_layer.rs, envelope/control_response.rs, endpoints/*.rs (health, models, estimate_cost, generate_image, generate_video, generate_object, generate_world, bg_removal, tasks, media_download, media_list, credits, scene), scene_bridge/{emit_scene_request.rs, await_bridge_reply.rs, scene_op.rs}}`; `commands/control/control_bridge_reply_command.rs`; `events/control_scene_request_event.rs`; `lifecycle/startup/tasks/spawn_control_server_thread.rs` (bind `127.0.0.1:0`, write state file, `tauri::async_runtime::spawn(axum::serve(..))`, log-and-continue on failure — never crash the app).
+
+**New frontend**: `frontend/libs/tauri-events/src/lib/events/functional/ControlSceneRequestEvent.ts` (EVENT_NAME `"control_scene_request"`); `frontend/libs/tauri-api/src/lib/control/ControlBridgeReply.ts`; `frontend/apps/artcraft/app/src/control/ControlBridge.tsx` (renders null).
+
+**New MCP**: `mcp/artcraft-mcp/` top-level dir (outside Nx and cargo workspaces): `package.json, tsconfig.json, README.md, src/{index.ts, control-client.ts, format.ts, tools/{generation,tasks,media,scene,status}.ts}, evals/`.
+
+**Edited upstream files (8, keep patch rebasable)**:
+1. root `Cargo.toml` — axum in workspace deps
+2. `crates/desktop/artcraft/Cargo.toml` — axum, uuid
+3. `crates/desktop/artcraft/src/lib.rs` — `.manage(ControlBridgeState)` (~line 196-209) + register `control_bridge_reply_command` (~line 213-265; must stay in lib.rs) + mod wiring
+4. `crates/desktop/artcraft/src/core/lifecycle/startup/handle_tauri_startup.rs` — import + one spawn call
+5. `crates/schema/public/enums/src/tauri/ux/tauri_event_name.rs` — `ControlSceneRequest` variant (`#[serde(rename = "control_scene_request")]`, name ends `_event` convention check)
+6. `frontend/apps/artcraft/app/src/root.tsx` — mount `<ControlBridge />` next to `<Outlet />` inside `<PostHogProvider>` (verified: App at line 45)
+7. `frontend/libs/tauri-events/src/index.ts` — export line
+8. `frontend/libs/tauri-api/src/index.ts` — export line
+(+ append-only `mod.rs` lines in commands/, events/, startup/tasks/)
+
+Repo conventions: two-space indent, `log` macros not `println!`, one command per file, constants-first file layout, `ResponseOrErrorMessage<T>` responses, `maybe_` optional fields.
+
+## Implementation order
+
+1. **Toolchain check + first build** (riskiest step, do first): Node ≥20, npm (pnpm blocked), `cargo install tauri-cli --version "^2"`; terminal 1 `./script/artcraft/unix_frontend_dev.sh`, terminal 2 `./script/artcraft/unix_rust_dev.sh` (both from repo root). Confirm stock app builds, launches, and reuses existing login before touching anything. Work on a branch (`git checkout -b mcp-control`).
+2. Control server skeleton: health + models + credits → curl smoke test.
+3. Remaining Path A endpoints (generate/tasks/media/cost/download) → curl a cheap image generation end-to-end. Audit each target command's `handle_request` signature first; prefer inner fns; widen visibility only in the command's own file; anything window-bound goes via scene bridge instead.
+4. Scene bridge (enum variant, event, reply command, ControlBridge component, root.tsx mount) → curl scene ops with 3D tab open and closed.
+5. MCP server + `npx @modelcontextprotocol/inspector` testing.
+6. Claude Code registration (`claude mcp add artcraft -- node .../mcp/artcraft-mcp/dist/index.js`), end-to-end: "generate an image, place it in the scene, move it up 2 units".
+7. Evals per build-mcp skill: 10 read-only Q&A (models count/providers, credits balance, cost estimate, task queue state, scene object count/positions/hidden objects, library search, login/version, aspect ratios) in the skill's XML format; seed a known 3-object scene + known library item first.
+
+## Risks
+
+- `handle_request` signature variance → audit per-command before wiring; fall back to scene-bridge-style dispatch for anything window-bound.
+- Rebase drift → 8 edited files (5 append-only); all logic in new files; document edit points in README.
+- Bridge hangs → hard 10s timeout, map cleanup on both paths; unknown request_id replies dropped with log.
+- Stale discovery file → MCP health-checks and re-reads on connection-refused; pid in file.
+- Credits spend in testing → estimate_cost first, cheapest model, batch_size 1; evals read-only.
+- `scene_apply` clobbers work → warning in tool description; surgical edits go through `scene_update_object`.
+
+## Verification
+
+- Curl matrix: 401 without token; health/models/credits/tasks with token; `SCENE_NOT_ACTIVE` when 3D tab closed; timeout path.
+- Inspector: every tool once; `scene_update_object` visually confirmed live in the open window; `scene_get`→`scene_apply` unmodified round-trip = no visual change.
+- Claude Code end-to-end prompt exercising generate → wait → download → scene edit.
+- Eval file run per build-mcp skill harness.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,13 @@
 # Local scratchpad — ArtCraft MCP
 
-Plan scratch only. The source of truth for work items is the Linear project "ArtCraft MCP" (team Hive Mind). Lessons go to the Linear "Lessons Log" document, not here.
+Linear is the record; this file is the resume map for the next session.
+
+## 2026-08-12 — Round 1 in flight (orchestrator)
+
+1. **Phase:** round 1, single lane launched, waiting on executor. Board: HM-914 Done; HM-915 In Progress (owned by this session's executor); HM-916..927 Backlog, all gated on HM-915→HM-916.
+2. **Running background work:** Opus executor on HM-915 (agent notification pending in this session; not resumable cross-session — if session died, treat lane as stale, see step below).
+3. **Lane HM-915:** verification-only issue; runs in the LIVE tree /Users/johngreenhow/Artcraft/artcraft-src on `main` @ bed3bad43c (accepted deviation, disclosed on the issue: no branch/worktree/PR, zero commits — stock dev-build proof). Executor will post one wrap-up comment and move to In Review. Hazard: two dev processes (Vite :5173, cargo tauri dev) may be running; executor terminates them on success.
+4. **Open decisions:** none.
+5. **Cold-start successor:** step 1 — check HM-915 in Linear: if In Review with wrap-up, proceed to round 2 (lane = HM-916, worktree branch `john/hm-916-...` off main, Opus); if still In Progress with no wrap-up and no live build processes (`pgrep -f 'cargo tauri'`), the executor died — kill stray Vite/cargo processes, re-run HM-915 per its plan comment, in the live tree, no commits.
+
+Coordination docs committed and pushed as bed3bad43c on main (origin=performance-clickt/artcraft).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,7 +2,14 @@
 
 Linear is the record; this file is the resume map for the next session.
 
-## 2026-08-12 — Round 1 in flight (orchestrator)
+## 2026-08-12 (later) — Round 1: cmake blocker resolved, executor resumed
+
+1. **Phase:** round 1, lane HM-915 resumed after halt. Executor hit missing `cmake` (boring-sys2 build dep) at 621/810 crates and halted per rules; John approved `brew install cmake` (v4.4.2 installed); executor resumed in background to re-run the build, verify logged-in launch, post wrap-up, move HM-915 → In Review.
+2. **Frontend already verified PASS** (Vite :5173, 200 OK). Toolchain: node v22.22.2, rustc/cargo 1.96.0, cargo tauri 2.11.4 (installed by executor), global nx v23.1.1 (installed by executor — undocumented prerequisite of unix_frontend_dev.sh).
+3. **Lesson candidates queued for learnings loop:** (a) verify native build deps (cmake etc.) up front, not just language toolchains; (b) `_docs/dev_setup.md` omits cmake and global nx → new-issue candidate for a docs fix.
+4. **Cold-start successor:** step 1 — check HM-915: In Review + wrap-up = done, start round 2 (lane HM-916); still In Progress with no build running (`pgrep -f 'cargo tauri'`) = executor died, re-run both dev scripts from repo root (cmake now present), verify, wrap up, In Review.
+
+## 2026-08-12 — Round 1 in flight (orchestrator) (superseded)
 
 1. **Phase:** round 1, single lane launched, waiting on executor. Board: HM-914 Done; HM-915 In Progress (owned by this session's executor); HM-916..927 Backlog, all gated on HM-915→HM-916.
 2. **Running background work:** Opus executor on HM-915 (agent notification pending in this session; not resumable cross-session — if session died, treat lane as stale, see step below).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,3 @@
+# Local scratchpad — ArtCraft MCP
+
+Plan scratch only. The source of truth for work items is the Linear project "ArtCraft MCP" (team Hive Mind). Lessons go to the Linear "Lessons Log" document, not here.


### PR DESCRIPTION
## Summary
- Adds cmake as a documented prerequisite before the Rust build step (needed for BoringSSL via `boring-sys2`, a dependency of `wreq`; the build otherwise fails with "is `cmake` not installed?")
- Documents that nx must be installed globally (`npm install -g nx`), since `script/artcraft/unix_frontend_dev.sh` calls bare `nx` and bash won't resolve it from `node_modules/.bin`
- Updates the known-good version list to the 2026-08-12 verified set from HM-915: Node v22.22.2, npm 10.9.7, rustc/cargo 1.96.0, cargo-tauri 2.11.4, nx 23.1.1 (global), cmake 4.4.2 — keeps the Node ≥ 20 minimum

## Context
Found while executing HM-915: `cargo tauri dev` failed on a fresh machine because cmake and global nx were undocumented prerequisites, and the doc's known-good versions were stale.

## Test plan
- [x] `git diff --stat` touches only `_docs/dev_setup.md`
- [x] Reviewed rendered markdown for broken list formatting
- [x] cmake and global nx each appear before the step that needs them

🤖 Generated with [Claude Code](https://claude.com/claude-code)