### PR TITLE
Test multiline prompt paste and focus-mode sizing

### DIFF
--- a/frontend/libs/components/promptbox/src/lib/MentionTextarea.spec.tsx
+++ b/frontend/libs/components/promptbox/src/lib/MentionTextarea.spec.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MentionTextarea, type MentionItem } from "./MentionTextarea";
+
+const MULTILINE_PROMPT = "Opening beat\n\nSecond beat\nThird beat";
+
+function PromptHarness({
+  initialValue = "",
+  mentionItems = [],
+}: {
+  initialValue?: string;
+  mentionItems?: MentionItem[];
+}) {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <>
+      <output data-testid="prompt-value">{value}</output>
+      <MentionTextarea
+        value={value}
+        onChange={setValue}
+        mentionItems={mentionItems}
+        colorMap={{}}
+      />
+    </>
+  );
+}
+
+function getEditor(): HTMLDivElement {
+  const editor = document.querySelector<HTMLDivElement>(
+    '[contenteditable="true"]',
+  );
+  if (!editor) throw new Error("MentionTextarea editor was not rendered");
+  return editor;
+}
+
+function selectEditorContents(editor: HTMLDivElement): void {
+  editor.focus();
+  const range = document.createRange();
+  range.selectNodeContents(editor);
+  const selection = window.getSelection();
+  if (!selection) throw new Error("Selection API is unavailable");
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function pastePlainText(editor: HTMLDivElement, text: string): void {
+  fireEvent.paste(editor, {
+    clipboardData: {
+      getData: (type: string) => (type === "text/plain" ? text : ""),
+    },
+  });
+}
+
+describe("MentionTextarea paste and focus-mode layout", () => {
+  it("preserves blank lines after the editor has already been edited and cleared", () => {
+    render(<PromptHarness initialValue="Earlier prompt" />);
+    const editor = getEditor();
+
+    selectEditorContents(editor);
+    pastePlainText(editor, "Temporary prompt");
+    expect(screen.getByTestId("prompt-value").textContent).toBe(
+      "Temporary prompt",
+    );
+
+    editor.innerHTML = "";
+    fireEvent.input(editor);
+    expect(screen.getByTestId("prompt-value").textContent).toBe("");
+
+    selectEditorContents(editor);
+    pastePlainText(editor, MULTILINE_PROMPT);
+
+    expect(screen.getByTestId("prompt-value").textContent).toBe(
+      MULTILINE_PROMPT,
+    );
+    expect(editor.querySelectorAll("br")).toHaveLength(3);
+  });
+
+  it("replaces a selection containing an atomic mention without losing newlines", () => {
+    const character: MentionItem = {
+      label: "@Hero",
+      type: "character",
+      token: "character-token",
+    };
+    render(
+      <PromptHarness
+        initialValue="@Hero old prompt"
+        mentionItems={[character]}
+      />,
+    );
+    const editor = getEditor();
+
+    selectEditorContents(editor);
+    pastePlainText(editor, MULTILINE_PROMPT);
+
+    expect(screen.getByTestId("prompt-value").textContent).toBe(
+      MULTILINE_PROMPT,
+    );
+    expect(editor.querySelector("[data-mention]")).toBeNull();
+    expect(editor.querySelectorAll("br")).toHaveLength(3);
+  });
+
+  it("allows its fullscreen flex wrapper to shrink so the editor can scroll", () => {
+    render(<PromptHarness />);
+
+    expect(getEditor().parentElement?.classList.contains("min-h-0")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed

- add focused regression coverage for multiline prompt paste after edit/clear cycles
- verify replacement of an atomic mention preserves blank lines
- lock in the `min-h-0` fullscreen wrapper required for wheel scrolling

## Why

The underlying paste and focus-mode sizing fixes are already on `main`, but their state-dependent failure modes did not have direct component-level regression coverage. These tests protect the literal newline transaction and the flex shrink constraint without changing production behavior.

## Validation

- `npx nx run @storyteller/ui-promptbox:test --skip-nx-cache` — 3/3 tests passed; all 30 dependencies built
- targeted Prettier check passed
- targeted ESLint returned zero errors (the spec path is ignored by the current lint configuration)
- `git diff --check` passed
