### PR TITLE
Fix iOS page-reload crash when adding image prompts + upload flicker

### DIFF
--- a/frontend/apps/artcraft-webapp/src/components/prompt-box/ImagePromptRow.tsx
+++ b/frontend/apps/artcraft-webapp/src/components/prompt-box/ImagePromptRow.tsx
@@ -1,6 +1,4 @@
 import {
-  useEffect,
-  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -12,6 +10,10 @@ import { Tooltip } from "@storyteller/ui-tooltip";
 import { Modal } from "@storyteller/ui-modal";
 import { twMerge } from "tailwind-merge";
 import { UploaderStates } from "@storyteller/common";
+import {
+  createImagePreviewUrl,
+  revokeIfBlobUrl,
+} from "@storyteller/ui-promptbox";
 import {
   DndContext,
   closestCenter,
@@ -76,13 +78,23 @@ export const ImagePromptRow = ({
     if (rootRef.current?.contains(e.target as Node)) e.stopPropagation();
   };
   const [uploadingEndFrame, setUploadingEndFrame] = useState(false);
+  // `previewUrl` is a downscaled object URL, empty until the downscale
+  // finishes. Full-res previews (base64 data URLs of camera photos) used to
+  // OOM-crash iOS tabs, which reloaded the page and wiped the deck.
   const [uploadingImages, setUploadingImages] = useState<
-    { id: string; file: File }[]
+    { id: string; previewUrl: string }[]
   >([]);
   const [previewImage, setPreviewImage] = useState<RefImage | null>(null);
 
   const referenceImagesRef = useRef(referenceImages);
   referenceImagesRef.current = referenceImages;
+
+  // Committed refs land in the page's store one render before the local
+  // entry removal — commits reuse the entry's id, so hide entries whose ref
+  // is already committed to avoid the card flashing next to its spinner.
+  const visibleUploadingImages = uploadingImages.filter(
+    (entry) => !referenceImages.some((img) => img.id === entry.id),
+  );
 
   const allowReorder = maxImagePromptCount > 1 && referenceImages.length > 1;
 
@@ -95,7 +107,7 @@ export const ImagePromptRow = ({
 
   const usedSlots = Math.min(
     maxImagePromptCount,
-    referenceImages.length + uploadingImages.length,
+    referenceImages.length + visibleUploadingImages.length,
   );
 
   const handleRemoveReference = (id: string) => {
@@ -107,7 +119,8 @@ export const ImagePromptRow = ({
     const files = Array.from(event.target.files || []);
     if (files.length === 0) return;
 
-    const currentCount = referenceImages.length + uploadingImages.length;
+    const currentCount =
+      referenceImages.length + visibleUploadingImages.length;
     const availableSlots = Math.max(0, maxImagePromptCount - currentCount);
     if (availableSlots <= 0) {
       if (fileInputRef.current) fileInputRef.current.value = "";
@@ -116,41 +129,46 @@ export const ImagePromptRow = ({
 
     const filesToProcess = files.slice(0, availableSlots);
 
-    filesToProcess.forEach((file) => {
+    filesToProcess.forEach(async (file) => {
       const uploadId = Math.random().toString(36).substring(7);
-      setUploadingImages((prev) => [...prev, { id: uploadId, file }]);
+      setUploadingImages((prev) => [...prev, { id: uploadId, previewUrl: "" }]);
 
-      const reader = new FileReader();
-      reader.onloadend = async () => {
-        await uploadImage({
-          title: `reference-image-${Math.random().toString(36).substring(2, 15)}`,
-          assetFile: file,
-          progressCallback: (newState) => {
-            if (newState.status === UploaderStates.success && newState.data) {
-              const refImage: RefImage = {
-                id: Math.random().toString(36).substring(7),
-                url: reader.result as string,
-                file,
-                mediaToken: newState.data,
-              };
-              setUploadingImages((prev) =>
-                prev.filter((img) => img.id !== uploadId),
-              );
-              setReferenceImages([...referenceImagesRef.current, refImage]);
-            } else if (
-              newState.status === UploaderStates.assetError ||
-              newState.status === UploaderStates.imageCreateError
-            ) {
-              setUploadingImages((prev) =>
-                prev.filter((img) => img.id !== uploadId),
-              );
-            }
-          },
-        });
+      // Downscaled preview; the committed thumbnail reuses it while the
+      // original file backs the full-res preview modal via `fullUrl`.
+      const previewUrl = await createImagePreviewUrl(file);
+      setUploadingImages((prev) =>
+        prev.map((e) => (e.id === uploadId ? { ...e, previewUrl } : e)),
+      );
 
-        if (fileInputRef.current) fileInputRef.current.value = "";
-      };
-      reader.readAsDataURL(file);
+      const removeEntry = () =>
+        setUploadingImages((prev) => prev.filter((img) => img.id !== uploadId));
+
+      await uploadImage({
+        title: `reference-image-${Math.random().toString(36).substring(2, 15)}`,
+        assetFile: file,
+        progressCallback: (newState) => {
+          if (newState.status === UploaderStates.success && newState.data) {
+            // Same id as the uploading entry so the card swaps in place.
+            const refImage: RefImage = {
+              id: uploadId,
+              url: previewUrl,
+              fullUrl: URL.createObjectURL(file),
+              file,
+              mediaToken: newState.data,
+            };
+            removeEntry();
+            setReferenceImages([...referenceImagesRef.current, refImage]);
+          } else if (
+            newState.status === UploaderStates.assetError ||
+            newState.status === UploaderStates.imageCreateError
+          ) {
+            revokeIfBlobUrl(previewUrl);
+            removeEntry();
+          }
+        },
+      });
+
+      if (fileInputRef.current) fileInputRef.current.value = "";
     });
   };
 
@@ -163,40 +181,42 @@ export const ImagePromptRow = ({
     setReferenceImages(arrayMove(referenceImages, oldIndex, newIndex));
   };
 
-  const handleEndFrameUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleEndFrameUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
     const file = event.target.files?.[0];
     if (!file || !setEndFrameImage) return;
 
     setUploadingEndFrame(true);
-    const reader = new FileReader();
-    reader.onloadend = async () => {
-      await uploadImage({
-        title: `end-frame-${Math.random().toString(36).substring(2, 15)}`,
-        assetFile: file,
-        progressCallback: (newState) => {
-          if (newState.status === UploaderStates.success && newState.data) {
-            setEndFrameImage({
-              id: Math.random().toString(36).substring(7),
-              url: reader.result as string,
-              file,
-              mediaToken: newState.data,
-            });
-            setUploadingEndFrame(false);
-          } else if (
-            newState.status === UploaderStates.assetError ||
-            newState.status === UploaderStates.imageCreateError
-          ) {
-            setUploadingEndFrame(false);
-          }
-        },
-      });
-      if (endFrameInputRef.current) endFrameInputRef.current.value = "";
-    };
-    reader.readAsDataURL(file);
+    const previewUrl = await createImagePreviewUrl(file);
+    await uploadImage({
+      title: `end-frame-${Math.random().toString(36).substring(2, 15)}`,
+      assetFile: file,
+      progressCallback: (newState) => {
+        if (newState.status === UploaderStates.success && newState.data) {
+          setEndFrameImage({
+            id: Math.random().toString(36).substring(7),
+            url: previewUrl,
+            fullUrl: URL.createObjectURL(file),
+            file,
+            mediaToken: newState.data,
+          });
+          setUploadingEndFrame(false);
+        } else if (
+          newState.status === UploaderStates.assetError ||
+          newState.status === UploaderStates.imageCreateError
+        ) {
+          revokeIfBlobUrl(previewUrl);
+          setUploadingEndFrame(false);
+        }
+      },
+    });
+    if (endFrameInputRef.current) endFrameInputRef.current.value = "";
   };
 
   const canAddMore =
-    referenceImages.length + uploadingImages.length < maxImagePromptCount;
+    referenceImages.length + visibleUploadingImages.length <
+    maxImagePromptCount;
 
   // Context-aware labels
   const sectionLabel = isVideo
@@ -297,13 +317,13 @@ export const ImagePromptRow = ({
                 ))
             )}
 
-            {uploadingImages
+            {visibleUploadingImages
               .slice(
                 0,
                 Math.max(0, maxImagePromptCount - referenceImages.length),
               )
-              .map(({ id, file }) => (
-                <UploadingThumbnail key={id} file={file} />
+              .map(({ id, previewUrl }) => (
+                <UploadingThumbnail key={id} previewUrl={previewUrl} />
               ))}
 
             {canAddMore && (
@@ -356,10 +376,7 @@ export const ImagePromptRow = ({
                 </div>
               ) : uploadingEndFrame ? (
                 <div className="flex aspect-square w-10 sm:w-14 items-center justify-center overflow-hidden rounded-lg border-2 border-white/30 bg-white/5">
-                  <LoaderCircleIcon
-                    
-                    spin
-                    className="h-5 w-5 text-white" />
+                  <LoaderCircleIcon className="h-5 w-5 animate-spin text-white" />
                 </div>
               ) : (
                 <AddButton
@@ -599,23 +616,20 @@ const SortableImage = ({
   );
 };
 
-const UploadingThumbnail = ({ file }: { file: File }) => {
-  const previewUrl = useMemo(() => URL.createObjectURL(file), [file]);
-  useEffect(() => () => URL.revokeObjectURL(previewUrl), [previewUrl]);
+const UploadingThumbnail = ({ previewUrl }: { previewUrl: string }) => {
   return (
     <div className="glass relative aspect-square w-10 sm:w-14 overflow-hidden rounded-lg border-2 border-white/30">
-      <div className="absolute inset-0">
-        <img
-          src={previewUrl}
-          alt="Uploading preview"
-          className="h-full w-full object-cover blur-sm"
-        />
-      </div>
+      {previewUrl && (
+        <div className="absolute inset-0">
+          <img
+            src={previewUrl}
+            alt="Uploading preview"
+            className="h-full w-full object-cover blur-sm"
+          />
+        </div>
+      )}
       <div className="absolute inset-0 flex items-center justify-center bg-black/20">
-        <LoaderCircleIcon
-          
-          spin
-          className="h-6 w-6 text-white" />
+        <LoaderCircleIcon className="h-6 w-6 animate-spin text-white" />
       </div>
     </div>
   );

--- a/frontend/libs/components/promptbox/src/index.ts
+++ b/frontend/libs/components/promptbox/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./lib/common/AspectRatioIcon";
 export * from "./lib/common/audioFiles";
+export * from "./lib/common/imagePreview";
 export * from "./lib/PromptBox2D";
 export * from "./lib/PromptBox3D";
 export * from "./lib/PromptBoxEdit";

--- a/frontend/libs/components/promptbox/src/lib/ImagePromptRow.tsx
+++ b/frontend/libs/components/promptbox/src/lib/ImagePromptRow.tsx
@@ -13,6 +13,10 @@ import { downloadFileFromUrl } from "@storyteller/api";
 import { ImageIcon, ImagesIcon, LoaderCircleIcon, MusicIcon, PlayIcon, PlusIcon, SquareIcon, Trash2Icon, VideoIcon, XIcon } from "lucide-react";
 import { DynamicIcon } from "@storyteller/icons";
 import { RefImage, RefVideo, RefAudio } from "./promptStore";
+import {
+  createImagePreviewUrl,
+  revokeIfBlobUrl,
+} from "./common/imagePreview";
 import { toast } from "@storyteller/ui-toaster";
 import { twMerge } from "tailwind-merge";
 import { UploaderStates } from "@storyteller/common";
@@ -181,8 +185,10 @@ export const ImagePromptRow = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const videoFileInputRef = useRef<HTMLInputElement>(null);
   const audioFileInputRef = useRef<HTMLInputElement>(null);
+  // `previewUrl` is a downscaled object URL, empty until the downscale
+  // finishes (full-res uploading previews used to OOM-crash iOS tabs).
   const [uploadingImages, setUploadingImages] = useState<
-    { id: string; file: File }[]
+    { id: string; file: File; previewUrl: string }[]
   >([]);
   const [isGalleryModalOpen, setIsGalleryModalOpen] = useState(false);
   const [galleryTarget, setGalleryTarget] = useState<"start" | "end" | "video">(
@@ -197,6 +203,7 @@ export const ImagePromptRow = ({
   const [uploadingEnd, setUploadingEnd] = useState<{
     id: string;
     file: File;
+    previewUrl: string;
   } | null>(null);
   const [uploadingVideo, setUploadingVideo] = useState<{
     id: string;
@@ -212,6 +219,17 @@ export const ImagePromptRow = ({
   useEffect(() => {
     referenceImagesRef.current = referenceImages;
   }, [referenceImages]);
+
+  // Committed refs land in the caller's store one render before the local
+  // entry removal — commits reuse the entry's id, so hide entries whose ref
+  // is already committed to avoid the card flashing next to its spinner.
+  const visibleUploadingImages = useMemo(
+    () =>
+      uploadingImages.filter(
+        (entry) => !referenceImages.some((img) => img.id === entry.id),
+      ),
+    [uploadingImages, referenceImages],
+  );
 
   const allowReorder = useMemo(
     () => maxImagePromptCount > 1 && referenceImages.length > 1,
@@ -306,28 +324,32 @@ export const ImagePromptRow = ({
     () =>
       Math.min(
         maxImagePromptCount,
-        referenceImages.length + uploadingImages.length,
+        referenceImages.length + visibleUploadingImages.length,
       ),
-    [maxImagePromptCount, referenceImages.length, uploadingImages.length],
+    [maxImagePromptCount, referenceImages.length, visibleUploadingImages.length],
   );
   const availableSlotsRender = useMemo(
     () =>
       Math.max(
         0,
-        maxImagePromptCount - referenceImages.length - uploadingImages.length,
+        maxImagePromptCount -
+          referenceImages.length -
+          visibleUploadingImages.length,
       ),
-    [maxImagePromptCount, referenceImages.length, uploadingImages.length],
+    [maxImagePromptCount, referenceImages.length, visibleUploadingImages.length],
   );
 
   useEffect(() => {
     const anyVisible =
       visible &&
-      (referenceImages.length > 0 || uploadingImages.length > 0 || allowUpload);
+      (referenceImages.length > 0 ||
+        visibleUploadingImages.length > 0 ||
+        allowUpload);
     onVisibilityChange?.(!!anyVisible);
   }, [
     visible,
     referenceImages.length,
-    uploadingImages.length,
+    visibleUploadingImages.length,
     allowUpload,
     onVisibilityChange,
   ]);
@@ -593,7 +615,8 @@ export const ImagePromptRow = ({
     const files = Array.from(event.target.files || []);
     if (files.length === 0) return;
 
-    const currentCount = referenceImages.length + uploadingImages.length;
+    const currentCount =
+      referenceImages.length + visibleUploadingImages.length;
     const availableSlots = Math.max(0, maxImagePromptCount - currentCount);
     if (availableSlots <= 0 && uploadTarget !== "end") {
       if (fileInputRef.current) fileInputRef.current.value = "";
@@ -605,83 +628,80 @@ export const ImagePromptRow = ({
         ? files.slice(0, 1)
         : files.slice(0, availableSlots);
 
-    filesToProcess.forEach((file) => {
+    filesToProcess.forEach(async (file) => {
       const uploadId = Math.random().toString(36).substring(7);
       if (uploadTarget === "end") {
-        setUploadingEnd({ id: uploadId, file });
+        setUploadingEnd({ id: uploadId, file, previewUrl: "" });
       } else {
-        setUploadingImages((prev) => [...prev, { id: uploadId, file }]);
+        setUploadingImages((prev) => [
+          ...prev,
+          { id: uploadId, file, previewUrl: "" },
+        ]);
       }
 
-      const reader = new FileReader();
-      reader.onloadend = async () => {
-        if (uploadImage) {
-          await uploadImage({
-            title: `reference-image-${Math.random()
-              .toString(36)
-              .substring(2, 15)}`,
-            assetFile: file,
-            progressCallback: (newState) => {
-              if (newState.status === UploaderStates.success && newState.data) {
-                const referenceImage: RefImage = {
-                  id: Math.random().toString(36).substring(7),
-                  url: reader.result as string,
-                  file,
-                  mediaToken: newState.data,
-                };
-                if (uploadTarget === "end") {
-                  setUploadingEnd(null);
-                } else {
-                  setUploadingImages((prev) =>
-                    prev.filter((img) => img.id !== uploadId),
-                  );
-                }
-                if (uploadTarget === "end") {
-                  setEndFrameImage?.(referenceImage);
-                } else {
-                  setReferenceImages([
-                    ...referenceImagesRef.current,
-                    referenceImage,
-                  ]);
-                }
-              } else if (
-                newState.status === UploaderStates.assetError ||
-                newState.status === UploaderStates.imageCreateError
-              ) {
-                if (uploadTarget === "end") {
-                  setUploadingEnd(null);
-                } else {
-                  setUploadingImages((prev) =>
-                    prev.filter((img) => img.id !== uploadId),
-                  );
-                }
-              }
-            },
-          });
-        } else {
-          const referenceImage: RefImage = {
-            id: Math.random().toString(36).substring(7),
-            url: reader.result as string,
-            file,
-            mediaToken: "",
-          };
-          if (uploadTarget === "end") {
-            setUploadingEnd(null);
-          } else {
-            setUploadingImages((prev) =>
-              prev.filter((img) => img.id !== uploadId),
-            );
-          }
-          if (uploadTarget === "end") {
-            setEndFrameImage?.(referenceImage);
-          } else {
-            setReferenceImages([...referenceImagesRef.current, referenceImage]);
-          }
-        }
+      // Downscaled preview; the committed thumbnail reuses it while the
+      // original file backs the full-res preview modal via `fullUrl`.
+      const previewUrl = await createImagePreviewUrl(file);
+      if (uploadTarget === "end") {
+        setUploadingEnd((prev) =>
+          prev && prev.id === uploadId ? { ...prev, previewUrl } : prev,
+        );
+      } else {
+        setUploadingImages((prev) =>
+          prev.map((e) => (e.id === uploadId ? { ...e, previewUrl } : e)),
+        );
+      }
 
-        if (fileInputRef.current) fileInputRef.current.value = "";
+      const removeEntry = () => {
+        if (uploadTarget === "end") {
+          setUploadingEnd(null);
+        } else {
+          setUploadingImages((prev) =>
+            prev.filter((img) => img.id !== uploadId),
+          );
+        }
       };
-      reader.readAsDataURL(file);
+
+      const commit = (mediaToken: string) => {
+        // Same id as the uploading entry so the card swaps in place.
+        const referenceImage: RefImage = {
+          id: uploadId,
+          url: previewUrl,
+          fullUrl: URL.createObjectURL(file),
+          file,
+          mediaToken,
+        };
+        removeEntry();
+        if (uploadTarget === "end") {
+          setEndFrameImage?.(referenceImage);
+        } else {
+          setReferenceImages([...referenceImagesRef.current, referenceImage]);
+        }
+      };
+
+      if (uploadImage) {
+        await uploadImage({
+          title: `reference-image-${Math.random()
+            .toString(36)
+            .substring(2, 15)}`,
+          assetFile: file,
+          progressCallback: (newState) => {
+            if (newState.status === UploaderStates.success && newState.data) {
+              commit(newState.data);
+            } else if (
+              newState.status === UploaderStates.assetError ||
+              newState.status === UploaderStates.imageCreateError
+            ) {
+              revokeIfBlobUrl(previewUrl);
+              removeEntry();
+            }
+          },
+        });
+      } else {
+        commit("");
+      }
+
+      if (fileInputRef.current) fileInputRef.current.value = "";
     });
   };
 
@@ -943,18 +963,17 @@ export const ImagePromptRow = ({
                       </div>
                     ))
                 )}
-                {uploadingImages
+                {visibleUploadingImages
                   .slice(
                     0,
                     Math.max(0, maxImagePromptCount - referenceImages.length),
                   )
-                  .map(({ id, file }) => {
-                    const previewUrl = URL.createObjectURL(file);
-                    return (
-                      <div
-                        key={id}
-                        className="glass relative aspect-square overflow-hidden rounded-lg w-14 border-2 border-white/30"
-                      >
+                  .map(({ id, previewUrl }) => (
+                    <div
+                      key={id}
+                      className="glass relative aspect-square overflow-hidden rounded-lg w-14 border-2 border-white/30"
+                    >
+                      {previewUrl && (
                         <div className="absolute inset-0">
                           <img
                             src={previewUrl}
@@ -962,15 +981,15 @@ export const ImagePromptRow = ({
                             className="h-full w-full object-cover blur-sm"
                           />
                         </div>
-                        <div className="absolute inset-0 flex items-center justify-center bg-black/20">
-                          <LoaderCircleIcon
-                            
-                            className="h-6 w-6 animate-spin text-white" />
-                        </div>
+                      )}
+                      <div className="absolute inset-0 flex items-center justify-center bg-black/20">
+                        <LoaderCircleIcon
+
+                          className="h-6 w-6 animate-spin text-white" />
                       </div>
-                    );
-                  })}
-                {referenceImages.length + uploadingImages.length <
+                    </div>
+                  ))}
+                {referenceImages.length + visibleUploadingImages.length <
                   maxImagePromptCount && (
                   <Tooltip
                     interactive={true}
@@ -1067,16 +1086,18 @@ export const ImagePromptRow = ({
                     </div>
                   ) : uploadingEnd ? (
                     <div className="glass relative aspect-square overflow-hidden rounded-lg w-14 border-2 border-white/30">
-                      <div className="absolute inset-0">
-                        <img
-                          src={URL.createObjectURL(uploadingEnd.file)}
-                          alt="Uploading preview"
-                          className="h-full w-full object-cover blur-sm"
-                        />
-                      </div>
+                      {uploadingEnd.previewUrl && (
+                        <div className="absolute inset-0">
+                          <img
+                            src={uploadingEnd.previewUrl}
+                            alt="Uploading preview"
+                            className="h-full w-full object-cover blur-sm"
+                          />
+                        </div>
+                      )}
                       <div className="absolute inset-0 flex items-center justify-center bg-black/20">
                         <LoaderCircleIcon
-                          
+
                           className="h-6 w-6 animate-spin text-white" />
                       </div>
                     </div>

--- a/frontend/libs/components/promptbox/src/lib/PromptBox2D.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBox2D.tsx
@@ -377,7 +377,7 @@ export const PromptBox2D = ({
             onImageClick={(image) => {
               setContent(
                 <img
-                  src={image.url}
+                  src={image.fullUrl ?? image.url}
                   alt="Reference preview"
                   className="w-full h-full object-contain"
                 />,

--- a/frontend/libs/components/promptbox/src/lib/PromptBox3D.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBox3D.tsx
@@ -693,7 +693,7 @@ export const PromptBox3D = ({
             onImageClick={(image) => {
               setContent(
                 <img
-                  src={image.url}
+                  src={image.fullUrl ?? image.url}
                   alt="Reference preview"
                   className="w-full h-full object-contain"
                 />,

--- a/frontend/libs/components/promptbox/src/lib/PromptBoxImage.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBoxImage.tsx
@@ -161,6 +161,7 @@ export const PromptBoxImage = ({
         id: img.id,
         kind: "image" as const,
         url: img.url,
+        previewUrl: img.fullUrl ?? img.url,
         name: `Image ${i + 1}`,
       })),
       ...deck.uploadingImages.map((entry, i) => ({

--- a/frontend/libs/components/promptbox/src/lib/PromptBoxVideo.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBoxVideo.tsx
@@ -561,6 +561,7 @@ export const PromptBoxVideo = ({
         id: img.id,
         kind: "image" as const,
         url: img.url,
+        previewUrl: img.fullUrl ?? img.url,
         name: `Image ${i + 1}`,
       })),
       ...deck.uploadingImages.map((entry, i) => ({
@@ -718,6 +719,7 @@ export const PromptBoxVideo = ({
         id: referenceImages[0].id,
         kind: "image",
         url: referenceImages[0].url,
+        previewUrl: referenceImages[0].fullUrl ?? referenceImages[0].url,
         name: "First frame",
       }
     : deck.uploadingImages[0]
@@ -735,6 +737,7 @@ export const PromptBoxVideo = ({
         id: endFrameImage.id,
         kind: "image",
         url: endFrameImage.url,
+        previewUrl: endFrameImage.fullUrl ?? endFrameImage.url,
         name: "Last frame",
       }
     : deck.uploadingEnd

--- a/frontend/libs/components/promptbox/src/lib/common/imagePreview.ts
+++ b/frontend/libs/components/promptbox/src/lib/common/imagePreview.ts
@@ -1,0 +1,83 @@
+/**
+ * Downscaled preview URLs for reference-image uploads.
+ *
+ * Committed reference thumbnails used to be full-resolution base64 data URLs
+ * (`FileReader.readAsDataURL`). A modern phone photo decodes to a 50–200MB
+ * bitmap plus a multi-megabyte heap string, so two or three camera-roll
+ * uploads crossed iOS WebKit's per-tab memory limit and the browser killed
+ * and reloaded the page, wiping the deck. Nothing ever needed that data URL:
+ * uploads send the original `File` and generation sends the media token, so
+ * previews only have to look right at deck-card size.
+ */
+
+const PREVIEW_MAX_DIM = 512;
+const PREVIEW_JPEG_QUALITY = 0.85;
+
+/** Formats whose previews must keep transparency through the re-encode. */
+const ALPHA_TYPES = new Set(["image/png", "image/webp", "image/avif"]);
+
+/** Formats returned as-is: GIFs keep their animation, SVGs are tiny vectors. */
+const PASSTHROUGH_TYPES = new Set(["image/gif", "image/svg+xml"]);
+
+// Downscales run one at a time: decoding is transient, but a multi-file pick
+// decoding three 48MP photos concurrently is its own OOM spike on iOS.
+let previewQueue: Promise<unknown> = Promise.resolve();
+
+/**
+ * Build a small object URL for displaying `file` as a reference thumbnail.
+ * Falls back to an object URL of the original file when the image can't be
+ * decoded (still far cheaper than a data URL — no base64 heap string).
+ */
+export function createImagePreviewUrl(file: File): Promise<string> {
+  const task = previewQueue.then(() => buildPreviewUrl(file));
+  previewQueue = task.catch(() => undefined);
+  return task;
+}
+
+/**
+ * Revoke a preview created by `createImagePreviewUrl`. No-op for non-blob
+ * URLs (library picks commit CDN URLs through the same fields).
+ */
+export function revokeIfBlobUrl(url: string | undefined) {
+  if (url && url.startsWith("blob:")) {
+    URL.revokeObjectURL(url);
+  }
+}
+
+async function buildPreviewUrl(file: File): Promise<string> {
+  if (PASSTHROUGH_TYPES.has(file.type)) {
+    return URL.createObjectURL(file);
+  }
+  try {
+    // from-image keeps EXIF rotation, so phone portraits don't turn sideways.
+    const bitmap = await createImageBitmap(file, {
+      imageOrientation: "from-image",
+    });
+    try {
+      const scale = Math.min(
+        1,
+        PREVIEW_MAX_DIM / Math.max(bitmap.width, bitmap.height),
+      );
+      if (scale >= 1) {
+        return URL.createObjectURL(file);
+      }
+      const canvas = document.createElement("canvas");
+      canvas.width = Math.max(1, Math.round(bitmap.width * scale));
+      canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        return URL.createObjectURL(file);
+      }
+      ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+      const type = ALPHA_TYPES.has(file.type) ? "image/png" : "image/jpeg";
+      const blob = await new Promise<Blob | null>((resolve) =>
+        canvas.toBlob(resolve, type, PREVIEW_JPEG_QUALITY),
+      );
+      return blob ? URL.createObjectURL(blob) : URL.createObjectURL(file);
+    } finally {
+      bitmap.close();
+    }
+  } catch {
+    return URL.createObjectURL(file);
+  }
+}

--- a/frontend/libs/components/promptbox/src/lib/deck/useDeckMedia.tsx
+++ b/frontend/libs/components/promptbox/src/lib/deck/useDeckMedia.tsx
@@ -8,11 +8,15 @@ import {
   AUDIO_FILE_TYPE_ERROR,
   isAudioFile,
 } from "../common/audioFiles";
+import { createImagePreviewUrl, revokeIfBlobUrl } from "../common/imagePreview";
 
 /** Minimal structural shapes so both apps' ref types fit. */
 export interface DeckRefLike {
   id: string;
   url: string;
+  /** Full-resolution URL for the tap-preview modal. Uploads set it to an
+   *  object URL of the original file; `url` is a downscaled thumbnail. */
+  fullUrl?: string;
   /** Set once the media file exists server-side (uploads fill it in late). */
   mediaToken?: string;
 }
@@ -20,7 +24,8 @@ export interface DeckMediaRefLike extends DeckRefLike {
   duration: number;
 }
 
-/** An in-flight upload; `previewUrl` is a memoized object URL. */
+/** An in-flight upload. `previewUrl` is an object URL; for images it's a
+ *  downscaled preview and stays empty until the downscale finishes. */
 export interface DeckUploadEntry {
   id: string;
   file: File;
@@ -173,12 +178,34 @@ export function useDeckMedia<
     referenceAudiosRef.current = referenceAudios;
   }, [referenceAudios]);
 
+  // Committed refs live in the caller's store, whose update can render one
+  // pass before this hook's entry-removal state lands — briefly showing the
+  // committed card AND its spinner. Commits reuse their entry's id, so
+  // hiding entries whose id is already committed removes that flicker (and
+  // the deck's keyed card morphs from spinner to thumbnail in place).
+  const visibleUploadingImages = useMemo(
+    () =>
+      uploadingImages.filter(
+        (entry) => !referenceImages.some((img) => img.id === entry.id),
+      ),
+    [uploadingImages, referenceImages],
+  );
+  const visibleUploadingVideo =
+    uploadingVideo && referenceVideos.some((v) => v.id === uploadingVideo.id)
+      ? null
+      : uploadingVideo;
+  const visibleUploadingAudio =
+    uploadingAudio && referenceAudios.some((a) => a.id === uploadingAudio.id)
+      ? null
+      : uploadingAudio;
+
   // The hook only ever commits `{ id, url, file, mediaToken, duration? }`,
   // which is structurally assignable to both apps' ref types (desktop
   // promptStore refs match exactly; the webapp's extra fields are optional).
   const asImage = (img: {
     id: string;
     url: string;
+    fullUrl?: string;
     file: File;
     mediaToken: string;
   }) => img as unknown as TImage;
@@ -226,7 +253,7 @@ export function useDeckMedia<
     files: File[],
     uploadTarget: "start" | "end",
   ) => {
-    const currentCount = referenceImages.length + uploadingImages.length;
+    const currentCount = referenceImages.length + visibleUploadingImages.length;
     const availableSlots = Math.max(0, maxImages - currentCount);
     if (availableSlots <= 0 && uploadTarget !== "end") {
       return;
@@ -237,31 +264,57 @@ export function useDeckMedia<
         ? files.slice(0, 1)
         : files.slice(0, availableSlots);
 
-    filesToProcess.forEach((file) => {
-      const entry = makeEntry(file);
+    filesToProcess.forEach(async (file) => {
+      // Register the slot synchronously (spinner card + slot accounting)…
+      const entryId = randomId();
       if (uploadTarget === "end") {
-        setUploadingEnd(entry);
+        setUploadingEnd({ id: entryId, file, previewUrl: "" });
       } else {
-        setUploadingImages((prev) => [...prev, entry]);
+        setUploadingImages((prev) => [
+          ...prev,
+          { id: entryId, file, previewUrl: "" },
+        ]);
       }
 
-      const finishEntry = () => {
-        URL.revokeObjectURL(entry.previewUrl);
+      // …then fill in the thumbnail once the downscale finishes. Full-res
+      // previews are what used to OOM-crash iOS tabs, so it's never the
+      // original pixels here.
+      const previewUrl = await createImagePreviewUrl(file);
+      if (uploadTarget === "end") {
+        setUploadingEnd((prev) =>
+          prev && prev.id === entryId ? { ...prev, previewUrl } : prev,
+        );
+      } else {
+        setUploadingImages((prev) =>
+          prev.map((e) => (e.id === entryId ? { ...e, previewUrl } : e)),
+        );
+      }
+
+      const removeEntry = () => {
         if (uploadTarget === "end") {
           setUploadingEnd(null);
         } else {
-          setUploadingImages((prev) => prev.filter((e) => e.id !== entry.id));
+          setUploadingImages((prev) => prev.filter((e) => e.id !== entryId));
         }
       };
 
-      const commit = (url: string, mediaToken: string) => {
+      const fail = () => {
+        revokeIfBlobUrl(previewUrl);
+        removeEntry();
+      };
+
+      const commit = (mediaToken: string) => {
+        // The downscaled preview lives on as the committed thumbnail; the
+        // original file backs the full-res tap-preview via `fullUrl`. The
+        // ref keeps the entry's id so the deck card swaps in place.
         const referenceImage = asImage({
-          id: randomId(),
-          url,
+          id: entryId,
+          url: previewUrl,
+          fullUrl: URL.createObjectURL(file),
           file,
           mediaToken,
         });
-        finishEntry();
+        removeEntry();
         if (uploadTarget === "end") {
           setEndFrameImage?.(referenceImage);
         } else {
@@ -269,29 +322,24 @@ export function useDeckMedia<
         }
       };
 
-      const reader = new FileReader();
-      reader.onloadend = async () => {
-        if (uploadImage) {
-          await uploadImage({
-            title: randomTitle("reference-image"),
-            assetFile: file,
-            progressCallback: (newState) => {
-              if (newState.status === UploaderStates.success && newState.data) {
-                commit(reader.result as string, newState.data);
-              } else if (
-                newState.status === UploaderStates.assetError ||
-                newState.status === UploaderStates.imageCreateError
-              ) {
-                finishEntry();
-              }
-            },
-          });
-        } else {
-          commit(reader.result as string, "");
-        }
-
-      };
-      reader.readAsDataURL(file);
+      if (uploadImage) {
+        await uploadImage({
+          title: randomTitle("reference-image"),
+          assetFile: file,
+          progressCallback: (newState) => {
+            if (newState.status === UploaderStates.success && newState.data) {
+              commit(newState.data);
+            } else if (
+              newState.status === UploaderStates.assetError ||
+              newState.status === UploaderStates.imageCreateError
+            ) {
+              fail();
+            }
+          },
+        });
+      } else {
+        commit("");
+      }
     });
   };
 
@@ -333,9 +381,10 @@ export function useDeckMedia<
 
       const commit = (mediaToken: string) => {
         // Reuse the entry's object URL as the committed thumbnail so it
-        // stays alive exactly as long as the ref does.
+        // stays alive exactly as long as the ref does, and the entry's id
+        // so the deck card swaps in place.
         const refVideo = asVideo({
-          id: randomId(),
+          id: entry.id,
           url: entry.previewUrl,
           file,
           mediaToken,
@@ -409,7 +458,7 @@ export function useDeckMedia<
 
       const commit = (mediaToken: string) => {
         const refAudio = asAudio({
-          id: randomId(),
+          id: entry.id,
           url: entry.previewUrl,
           file,
           mediaToken,
@@ -666,7 +715,7 @@ export function useDeckMedia<
 
   const availableImageSlots = Math.max(
     0,
-    maxImages - referenceImages.length - uploadingImages.length,
+    maxImages - referenceImages.length - visibleUploadingImages.length,
   );
 
   const fileInputs: ReactNode = (
@@ -776,10 +825,10 @@ export function useDeckMedia<
   ) : null;
 
   return {
-    uploadingImages,
+    uploadingImages: visibleUploadingImages,
     uploadingEnd,
-    uploadingVideo,
-    uploadingAudio,
+    uploadingVideo: visibleUploadingVideo,
+    uploadingAudio: visibleUploadingAudio,
     availableImageSlots,
     processImageFiles,
     processVideoFiles,

--- a/frontend/libs/components/promptbox/src/lib/promptStore.ts
+++ b/frontend/libs/components/promptbox/src/lib/promptStore.ts
@@ -5,7 +5,11 @@ import { CommonQuality } from "@storyteller/model-list";
 
 export interface RefImage {
   id: string;
+  /** Display thumbnail (downscaled object URL for uploads, CDN URL for
+   *  library picks). Never sent to the backend — that's `mediaToken`. */
   url: string;
+  /** Full-resolution URL for preview modals; falls back to `url`. */
+  fullUrl?: string;
   file: File;
   mediaToken: string;
 }


### PR DESCRIPTION
On iOS, adding more than 2 image prompts can blow past the browser's memory limit and force-reload the page, wiping your prompts. We were storing every uploaded image as a full-res base64 string just to show a 56px thumbnail.
- Thumbnails are now small ~512px previews instead of full-res data URLs (memory per image goes from ~100MB+ to under 1MB)
- Tapping a thumbnail still shows the original full-res image
- Nothing changes for the backend — uploads and generation still use the original file + media token
- Fixed the flicker when an upload finishes: the spinner card now turns into the image card in place, instead of a new card popping in next to it
- Small cleanups along the way: leaked object URLs in the old prompt row, and upload spinners that never actually spun

Applies to webapp (desktop + mobile), website, and the desktop app since they share the upload code.
