### PR TITLE
Focus mode drag & drop

### DIFF
--- a/frontend/apps/artcraft-webapp/src/components/prompt-box/PromptBox.tsx
+++ b/frontend/apps/artcraft-webapp/src/components/prompt-box/PromptBox.tsx
@@ -277,6 +277,17 @@ export const PromptBox = forwardRef<HTMLDivElement, PromptBoxProps>(
       onDropFiles: handleDroppedFiles,
     });
 
+    // One overlay element serves both drop zones (inline box + focus mode).
+    const dropOverlay = (
+      <PromptBoxDropOverlay
+        dragState={drop.dragState}
+        acceptsImages={dropAcceptsImages}
+        acceptsVideos={dropAcceptsVideos}
+        acceptsAudio={dropAcceptsAudio}
+        keyframeMode={isKeyframeMode}
+      />
+    );
+
     // Mixed deck items ordered images → videos → audios so the page's
     // index-derived @ImageN/@VideoN/@AudioN mention labels stay aligned.
     const deckItems: DeckItem[] = useMemo(
@@ -774,13 +785,7 @@ export const PromptBox = forwardRef<HTMLDivElement, PromptBoxProps>(
             )}
             {...drop.dropZoneProps}
           >
-            <PromptBoxDropOverlay
-              dragState={drop.dragState}
-              acceptsImages={dropAcceptsImages}
-              acceptsVideos={dropAcceptsVideos}
-              acceptsAudio={dropAcceptsAudio}
-              keyframeMode={isKeyframeMode}
-            />
+            {dropOverlay}
             <div className="flex gap-3">
               {renderReferenceWidget()}
               {referenceSlots}
@@ -985,6 +990,8 @@ export const PromptBox = forwardRef<HTMLDivElement, PromptBoxProps>(
           onClose={closeFullscreen}
           promptLength={prompt.length}
           maxPromptLength={maxPromptLength}
+          dropZoneProps={drop.dropZoneProps}
+          dropOverlay={dropOverlay}
           footerControls={
             <>
               {modelSelector}

--- a/frontend/apps/artcraft-webapp/src/components/prompt-box/PromptFullscreen.tsx
+++ b/frontend/apps/artcraft-webapp/src/components/prompt-box/PromptFullscreen.tsx
@@ -1,4 +1,11 @@
-import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import {
+  HTMLAttributes,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { Modal } from "@storyteller/ui-modal";
 import { Button } from "@storyteller/ui-button";
 import { Tooltip } from "@storyteller/ui-tooltip";
@@ -60,6 +67,13 @@ interface PromptFullscreenModalProps {
   imagePromptRow?: ReactNode;
   /** Clear-all control rendered on the footer's right side, left of Done. */
   clearAllButton?: ReactNode;
+  /** Drop-zone handlers (usePromptBoxDrop's `dropZoneProps`, the same object
+   *  the inline box spreads) so drag & drop keeps working while focus mode
+   *  covers the inline box. */
+  dropZoneProps?: HTMLAttributes<HTMLDivElement>;
+  /** The same PromptBoxDropOverlay element the inline box renders, shown over
+   *  the panel while files hover it. */
+  dropOverlay?: ReactNode;
 }
 
 export const PromptFullscreenModal = ({
@@ -71,6 +85,8 @@ export const PromptFullscreenModal = ({
   footerControls,
   imagePromptRow,
   clearAllButton,
+  dropZoneProps,
+  dropOverlay,
 }: PromptFullscreenModalProps) => {
   const showCounter =
     promptLength !== undefined && maxPromptLength !== undefined;
@@ -102,7 +118,12 @@ export const PromptFullscreenModal = ({
           is reliably bounded across the modal's nested wrappers — that's what
           lets the editor scroll instead of stretching the panel. min-h-0 lets
           the flex children shrink below content size. */}
-      <div className="flex min-h-0 flex-col gap-2" style={{ height: "70vh" }}>
+      <div
+        {...dropZoneProps}
+        className="relative flex min-h-0 flex-col gap-2"
+        style={{ height: "70vh" }}
+      >
+        {dropOverlay}
         <h2 className="shrink-0 text-lg font-bold text-base-fg">Prompt</h2>
         {/* flex-1 so the editor takes only the space left after the (shrink-0)
             image row + footer — keeps it from overflowing when the window is

--- a/frontend/libs/components/promptbox/src/lib/PromptBoxAudio.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBoxAudio.tsx
@@ -318,6 +318,16 @@ export const PromptBoxAudio = ({
     onDropFiles: handleDroppedFiles,
   });
 
+  // One overlay element serves both drop zones (inline box + focus mode).
+  const dropOverlay = (
+    <PromptBoxDropOverlay
+      dragState={drop.dragState}
+      acceptsImages={imageRefsSupported}
+      acceptsVideos={false}
+      acceptsAudio={audioRefsSupported}
+    />
+  );
+
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setPrompt(e.target.value);
   };
@@ -551,12 +561,7 @@ export const PromptBoxAudio = ({
           )}
           {...drop.dropZoneProps}
         >
-          <PromptBoxDropOverlay
-            dragState={drop.dragState}
-            acceptsImages={imageRefsSupported}
-            acceptsVideos={false}
-            acceptsAudio={audioRefsSupported}
-          />
+          {dropOverlay}
           {referenceRow}
 
           <div className="flex justify-center gap-2">
@@ -649,6 +654,8 @@ export const PromptBoxAudio = ({
         onClose={closeFullscreen}
         promptLength={prompt.length}
         maxLength={Infinity}
+        dropZoneProps={drop.fullscreenDropZoneProps}
+        dropOverlay={dropOverlay}
         clearAllButton={
           <PromptClearAllButton
             onClick={handleClearAll}

--- a/frontend/libs/components/promptbox/src/lib/PromptBoxImage.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBoxImage.tsx
@@ -155,6 +155,16 @@ export const PromptBoxImage = ({
     onDropFiles: handleDroppedFiles,
   });
 
+  // One overlay element serves both drop zones (inline box + focus mode).
+  const dropOverlay = (
+    <PromptBoxDropOverlay
+      dragState={drop.dragState}
+      acceptsImages={dropAcceptsImages}
+      acceptsVideos={false}
+      acceptsAudio={false}
+    />
+  );
+
   const deckItems: DeckItem[] = useMemo(
     () => [
       ...referenceImages.map((img, i) => ({
@@ -463,12 +473,7 @@ export const PromptBoxImage = ({
           )}
           {...drop.dropZoneProps}
         >
-          <PromptBoxDropOverlay
-            dragState={drop.dragState}
-            acceptsImages={dropAcceptsImages}
-            acceptsVideos={false}
-            acceptsAudio={false}
-          />
+          {dropOverlay}
           <div className="flex justify-center gap-2">
             {renderReferenceDeck()}
 
@@ -602,6 +607,8 @@ export const PromptBoxImage = ({
         onClose={closeFullscreen}
         promptLength={prompt.length}
         maxLength={maxLen}
+        dropZoneProps={drop.fullscreenDropZoneProps}
+        dropOverlay={dropOverlay}
         footerControls={modelSelector}
         imagePromptRow={renderReferenceDeck(true) ?? undefined}
         clearAllButton={

--- a/frontend/libs/components/promptbox/src/lib/PromptBoxVideo.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptBoxVideo.tsx
@@ -552,6 +552,17 @@ export const PromptBoxVideo = ({
     onDropFiles: handleDroppedFiles,
   });
 
+  // One overlay element serves both drop zones (inline box + focus mode).
+  const dropOverlay = (
+    <PromptBoxDropOverlay
+      dragState={drop.dragState}
+      acceptsImages={maxImageCount > 0}
+      acceptsVideos={dropAcceptsVideos}
+      acceptsAudio={dropAcceptsAudio}
+      keyframeMode={!isReferenceMode}
+    />
+  );
+
   // Mixed deck items ordered images → videos → audios: the @ImageN/@VideoN/
   // @AudioN mention labels are index-derived per type, so this ordering (and
   // image-only reordering) is load-bearing.
@@ -1342,13 +1353,7 @@ export const PromptBoxVideo = ({
           )}
           {...drop.dropZoneProps}
         >
-          <PromptBoxDropOverlay
-            dragState={drop.dragState}
-            acceptsImages={maxImageCount > 0}
-            acceptsVideos={dropAcceptsVideos}
-            acceptsAudio={dropAcceptsAudio}
-            keyframeMode={!isReferenceMode}
-          />
+          {dropOverlay}
           {selectedModel?.textToVideoSupported === false && (
             <div className="mb-2 flex items-center gap-1.5 rounded-md bg-ui-controls/60 px-2.5 py-1.5 text-xs text-base-fg/70">
               <InfoIcon
@@ -1610,6 +1615,8 @@ export const PromptBoxVideo = ({
         onClose={closeFullscreen}
         promptLength={prompt.length}
         maxLength={maxLen}
+        dropZoneProps={drop.fullscreenDropZoneProps}
+        dropOverlay={dropOverlay}
         clearAllButton={
           <PromptClearAllButton
             onClick={handleClearAll}

--- a/frontend/libs/components/promptbox/src/lib/PromptFullscreenModal.tsx
+++ b/frontend/libs/components/promptbox/src/lib/PromptFullscreenModal.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { Modal } from "@storyteller/ui-modal";
 import { Button } from "@storyteller/ui-button";
 import { focusEditorAtEnd } from "./focusEditorAtEnd";
+import { PromptBoxDropZoneProps } from "./deck/usePromptBoxDrop";
 
 // Shared "focus mode" overlay for prompt editors. Reuses @storyteller/ui-modal
 // (Trello-card style: centered panel + blurred backdrop) and renders whatever
@@ -37,6 +38,16 @@ interface PromptFullscreenModalProps {
    * the Done button (pass the box's PromptClearAllButton).
    */
   clearAllButton?: ReactNode;
+  /**
+   * Drop-zone wiring (usePromptBoxDrop's `fullscreenDropZoneProps`) so drag &
+   * drop keeps working while focus mode covers the inline box.
+   */
+  dropZoneProps?: PromptBoxDropZoneProps;
+  /**
+   * The same PromptBoxDropOverlay element the inline box renders, shown over
+   * the panel while files hover it.
+   */
+  dropOverlay?: ReactNode;
 }
 
 export const PromptFullscreenModal = ({
@@ -48,6 +59,8 @@ export const PromptFullscreenModal = ({
   footerControls,
   imagePromptRow,
   clearAllButton,
+  dropZoneProps,
+  dropOverlay,
 }: PromptFullscreenModalProps) => {
   const overLimit = isFinite(maxLength) && promptLength > maxLength;
   const contentRef = useRef<HTMLDivElement>(null);
@@ -76,7 +89,12 @@ export const PromptFullscreenModal = ({
           is reliably bounded across the modal's nested wrappers — that's what
           lets the editor's textarea scroll instead of stretching the panel.
           min-h-0 on the flex children lets them shrink below content size. */}
-      <div className="flex min-h-0 flex-col gap-2" style={{ height: "70vh" }}>
+      <div
+        {...dropZoneProps}
+        className="relative flex min-h-0 flex-col gap-2"
+        style={{ height: "70vh" }}
+      >
+        {dropOverlay}
         <h2 className="shrink-0 text-lg font-bold text-base-fg">Prompt</h2>
         {/* flex-1 so the editor takes only the space left after the (shrink-0)
             image row + footer — that's what keeps it from overflowing when the

--- a/frontend/libs/components/promptbox/src/lib/deck/usePromptBoxDrop.tsx
+++ b/frontend/libs/components/promptbox/src/lib/deck/usePromptBoxDrop.tsx
@@ -26,6 +26,15 @@ export interface UsePromptBoxDropOptions {
   onDropFiles: (files: DroppedFiles) => void;
 }
 
+/** Spreadable props that make an element a prompt-box drop target. */
+export interface PromptBoxDropZoneProps {
+  ref: React.RefObject<HTMLDivElement | null>;
+  onDragEnter: React.DragEventHandler<HTMLDivElement>;
+  onDragOver: React.DragEventHandler<HTMLDivElement>;
+  onDragLeave: React.DragEventHandler<HTMLDivElement>;
+  onDrop: React.DragEventHandler<HTMLDivElement>;
+}
+
 interface PromptBoxDropOverlayProps {
   dragState: DropDragState;
   acceptsImages: boolean;
@@ -135,6 +144,9 @@ export function usePromptBoxDrop({
 }: UsePromptBoxDropOptions) {
   const [dragState, setDragState] = useState<DropDragState>("idle");
   const zoneRef = useRef<HTMLDivElement>(null);
+  // Second zone for the focus-mode modal (PromptFullscreenModal); mounted
+  // only while it's open, when it visually covers the inline box.
+  const fullscreenZoneRef = useRef<HTMLDivElement>(null);
   const enabled = acceptsImages || acceptsVideos || acceptsAudio;
   const isDesktop = IsDesktopApp();
 
@@ -286,9 +298,10 @@ export function usePromptBoxDrop({
     let disposed = false;
 
     // Tauri reports positions in physical pixels; CSS coordinates need the
-    // display's scale factor divided back out.
+    // display's scale factor divided back out. While focus mode is open its
+    // zone covers the inline box, so it takes over the hit-test.
     const isInsideZone = (position: { x: number; y: number }) => {
-      const zone = zoneRef.current;
+      const zone = fullscreenZoneRef.current ?? zoneRef.current;
       if (!zone) return false;
       const scale = window.devicePixelRatio || 1;
       const x = position.x / scale;
@@ -411,6 +424,15 @@ export function usePromptBoxDrop({
       ref: zoneRef,
       // Under Tauri these never fire, but leaving them attached keeps a
       // single code path and costs nothing.
+      onDragEnter: handleDragOver,
+      onDragOver: handleDragOver,
+      onDragLeave: handleDragLeave,
+      onDrop: handleDrop,
+    },
+    // Same handlers with the focus-mode ref, for PromptFullscreenModal —
+    // drops there behave exactly like drops on the inline box.
+    fullscreenDropZoneProps: {
+      ref: fullscreenZoneRef,
       onDragEnter: handleDragOver,
       onDragOver: handleDragOver,
       onDragLeave: handleDragLeave,


### PR DESCRIPTION
Drag and drop didn't work while the prompt focus mode was open - the modal sat on top of the inline promptbox's drop zone, so files just did nothing (webapp and desktop).

### Changes

- `usePromptBoxDrop` now exposes `fullscreenDropZoneProps` - same handlers/routing, second ref so the Tauri hit-test follows the focus-mode modal while it's open
- `PromptFullscreenModal` (shared lib + webapp copy) takes optional `dropZoneProps` / `dropOverlay` and renders the drop zone + hover overlay on its panel
- Image / Video / Audio boxes + webapp `PromptBox` pass their existing drop wiring through - one overlay element now serves both the inline box and focus mode
- No new drop logic anywhere: same MIME routing, accept/reject toasts, keyframe handling, and paste behavior as dropping on the inline box