### PR TITLE
bump artcraft to 0.38 to test repo reset

### DIFF
--- a/crates/desktop/artcraft/src/version.rs
+++ b/crates/desktop/artcraft/src/version.rs
@@ -1,4 +1,4 @@
 
 /// The version of the ArtCraft desktop app reported in the UI and via Analytics.
 /// This should match the CI builds.
-pub const ARTCRAFT_VERSION: &str = "0.37.0";
+pub const ARTCRAFT_VERSION: &str = "0.38.0";

--- a/crates/desktop/artcraft/tauri-mac.conf.json
+++ b/crates/desktop/artcraft/tauri-mac.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "ArtCraft",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "identifier": "ai.artcraft.app",
   "build": {
     "frontendDist": "../../../frontend/apps/artcraft/dist",

--- a/crates/desktop/artcraft/tauri.conf.json
+++ b/crates/desktop/artcraft/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "ArtCraft",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "identifier": "ai.artcraft.app",
   "build": {
     "frontendDist": "../../../frontend/apps/artcraft/dist",


### PR DESCRIPTION
The entire repo was purged of ancillary code (backend, frontend, models, tools, etc.) and subsequently reset.

This is a no-op version that guarantees builds can continue on the new repo state.